### PR TITLE
feat: daily tasks workflow, slot control, stats fixes & premium admin UI

### DIFF
--- a/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.css
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.css
@@ -1,348 +1,164 @@
+/* ── Overview – Premium Dark-Green Admin Theme ── */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
 .overview-section {
-    padding: 2rem;
-    background: #f5f5f5;
-    min-height: 100vh;
+  padding: 28px 32px;
+  background: linear-gradient(135deg, #f0f7f0 0%, #f8fdf8 100%);
+  min-height: 100vh;
+  font-family: 'Inter', sans-serif;
 }
 
-.overview-section h1 {
-    color: #333;
-    margin-bottom: 0.5rem;
-    font-size: 2rem;
+/* ── Header ── */
+.ov-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 28px; flex-wrap: wrap; gap: 12px;
+}
+.ov-header-left h1 {
+  font-size: 1.7rem; font-weight: 800; color: #012a01; margin: 0 0 4px;
+  letter-spacing: -0.02em;
+}
+.ov-header-left p { font-size: 0.88rem; color: #666; margin: 0; }
+.ov-refresh-btn {
+  display: flex; align-items: center; gap: 8px;
+  background: #014a01; color: #fff; border: none;
+  padding: 9px 20px; border-radius: 8px; font-weight: 600;
+  font-size: 0.88rem; cursor: pointer; transition: all 0.18s;
+  box-shadow: 0 2px 8px rgba(1,74,1,0.3);
+}
+.ov-refresh-btn:hover { background: #012a01; transform: translateY(-1px); box-shadow: 0 4px 14px rgba(1,74,1,0.35); }
+
+/* ── KPI Cards ── */
+.ov-kpi-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 16px; margin-bottom: 28px;
+}
+.ov-kpi-card {
+  background: #fff; border-radius: 14px; padding: 22px 20px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+  border: 1.5px solid #e8f5e9;
+  display: flex; align-items: center; gap: 16px;
+  transition: all 0.22s; cursor: default; position: relative; overflow: hidden;
+}
+.ov-kpi-card::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--kpi-color, #014a01);
+  border-radius: 14px 14px 0 0;
+}
+.ov-kpi-card:hover { transform: translateY(-4px); box-shadow: 0 8px 24px rgba(0,0,0,0.12); }
+.ov-kpi-icon {
+  width: 52px; height: 52px; border-radius: 13px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.5rem; flex-shrink: 0;
+  background: var(--kpi-bg, #e6f4ea);
+}
+.ov-kpi-info h4 { font-size: 0.78rem; font-weight: 600; color: #888; margin: 0 0 4px; text-transform: uppercase; letter-spacing: 0.06em; }
+.ov-kpi-info p  { font-size: 2rem; font-weight: 800; color: #012a01; margin: 0; line-height: 1; }
+.ov-kpi-info small { font-size: 0.75rem; color: #aaa; }
+
+/* ── Section cards ── */
+.ov-section-card {
+  background: #fff; border-radius: 16px; padding: 24px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+  border: 1.5px solid #e8f5e9; margin-bottom: 24px;
+}
+.ov-section-title {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 1.05rem; font-weight: 700; color: #012a01;
+  margin: 0 0 20px; padding-bottom: 14px;
+  border-bottom: 2px solid #f0f7f0;
+}
+.ov-section-title span { font-size: 1.2rem; }
+
+/* ── Filters row ── */
+.ov-filters {
+  display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 18px;
+}
+.ov-filter-group { display: flex; flex-direction: column; gap: 5px; min-width: 140px; flex: 1; }
+.ov-filter-group label { font-size: 0.75rem; font-weight: 700; color: #555; text-transform: uppercase; letter-spacing: 0.05em; }
+.ov-filter-group select, .ov-filter-group input {
+  padding: 8px 12px; border: 1.5px solid #d8ecd8; border-radius: 8px;
+  font-size: 0.88rem; color: #333; background: #f9fdf9;
+  transition: all 0.18s; font-family: 'Inter', sans-serif;
+}
+.ov-filter-group select:hover, .ov-filter-group input:hover { border-color: #014a01; }
+.ov-filter-group select:focus, .ov-filter-group input:focus {
+  outline: none; border-color: #014a01;
+  box-shadow: 0 0 0 3px rgba(1,74,1,0.12);
 }
 
-.role-text {
-    color: #666;
-    margin-bottom: 2rem;
-    font-size: 1.1rem;
+/* ── Total count badge ── */
+.ov-total-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: #e6f4ea; color: #014a01; font-weight: 700;
+  font-size: 0.88rem; padding: 5px 14px; border-radius: 20px;
+  margin-bottom: 16px; border: 1px solid #b7dfb7;
 }
 
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
+/* ── District toggle btn ── */
+.ov-toggle-btn {
+  padding: 8px 16px; border-radius: 8px; font-weight: 600;
+  font-size: 0.82rem; cursor: pointer; transition: all 0.18s;
+  border: 1.5px solid #014a01; background: #fff; color: #014a01;
+  margin-top: 20px;
 }
+.ov-toggle-btn:hover { background: #014a01; color: #fff; }
+.ov-toggle-btn.active { background: #014a01; color: #fff; }
 
-.stat-card {
-    background: white;
-    padding: 1.5rem;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transition: transform 0.2s;
+/* ── Course stats grid ── */
+.ov-course-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 14px; margin-bottom: 24px;
 }
-
-.stat-card:hover {
-    transform: translateY(-5px);
+.ov-course-card {
+  background: linear-gradient(135deg, #f0f7f0, #e8f5e9);
+  border: 1.5px solid #c8e6c9; border-radius: 12px;
+  padding: 18px 16px; text-align: center;
+  transition: all 0.22s;
 }
+.ov-course-card:hover { transform: translateY(-3px); box-shadow: 0 6px 18px rgba(1,74,1,0.15); border-color: #014a01; }
+.ov-course-card h4 { font-size: 0.75rem; font-weight: 700; color: #555; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 8px; }
+.ov-course-card p  { font-size: 2.2rem; font-weight: 800; color: #014a01; margin: 0; line-height: 1; }
+.ov-course-card.red { background: linear-gradient(135deg, #fff1f0, #fde8e8); border-color: #ffa39e; }
+.ov-course-card.red p { color: #c62828; }
+.ov-course-card.blue { background: linear-gradient(135deg, #e3f2fd, #bbdefb); border-color: #90caf9; }
+.ov-course-card.blue p { color: #1565c0; }
+.ov-course-card.amber { background: linear-gradient(135deg, #fff8e1, #ffecb3); border-color: #ffe082; }
+.ov-course-card.amber p { color: #e65100; }
 
-.stat-content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+/* ── Marks distribution ── */
+.ov-marks-bar-row {
+  display: flex; flex-direction: column; gap: 10px; margin-top: 8px;
 }
-
-.stat-content h3 {
-    color: #666;
-    font-size: 0.9rem;
-    margin-bottom: 0.5rem;
+.ov-marks-row {
+  display: flex; align-items: center; gap: 14px;
 }
-
-.stat-content p {
-    color: #333;
-    font-size: 1.5rem;
-    font-weight: bold;
+.ov-marks-label { font-size: 0.82rem; font-weight: 600; color: #555; width: 80px; flex-shrink: 0; }
+.ov-marks-bar-wrap {
+  flex: 1; height: 28px; background: #f0f7f0; border-radius: 8px;
+  overflow: hidden; position: relative;
 }
-
-.stat-icon {
-    font-size: 1.5rem;
-    color: #970003;
+.ov-marks-bar-fill {
+  height: 100%; border-radius: 8px;
+  display: flex; align-items: center; padding-left: 10px;
+  font-size: 0.75rem; font-weight: 700; color: #fff;
+  transition: width 0.5s ease;
 }
+.ov-marks-count { font-size: 0.85rem; font-weight: 700; color: #333; width: 36px; text-align: right; flex-shrink: 0; }
 
-.charts-section {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: 2rem;
-    margin-bottom: 2rem;
-}
-
-.chart-container {
-    background-color: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    margin-bottom: 20px;
-    display: flex;
-    flex-direction: column;
-    /* align-items: center; */
-    justify-content: center;
-}
-
-.chart-container h2 {
-    margin: 0 0 20px 0;
-    color: #333;
-    font-size: 18px;
-}
-
-.beta-note {
-    color: #666;
-    font-size: 0.9rem;
-    text-align: center;
-    margin-top: 2rem;
-    padding: 1rem;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.loading {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 200px;
-    color: #666;
-    font-size: 1.1rem;
-}
-
-.error {
-    color: #ff4d4f;
-    text-align: center;
-    padding: 2rem;
-    background: #fff2f0;
-    border-radius: 8px;
-    margin: 2rem;
-}
-
-.no-data {
-    color: #666;
-    text-align: center;
-    padding: 2rem;
-    background: white;
-    border-radius: 8px;
-    margin: 2rem;
-}
-
-.filters {
-    display: flex;
-    gap: 20px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-}
-
-.filter-group {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    flex: 1;
-    min-width: 140px;
-}
-
-.filter-group label {
-    font-weight: 600;
-    color: #495057;
-    font-size: 0.8rem;
-}
-
-.filter-group select {
-    padding: 8px 12px;
-    border: 1px solid #ced4da;
-    border-radius: 4px;
-    font-size: 14px;
-    color: #495057;
-    background-color: white;
-    transition: border-color 0.15s ease-in-out;
-}
-
-.filter-group select:focus {
-    outline: none;
-    border-color: #80bdff;
-    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
-}
-
-.filter-group select:hover {
-    border-color: #adb5bd;
-}
-
+/* ── Geo chart ── */
+.ov-geo-total { font-size: 1rem; font-weight: 700; color: #333; margin-bottom: 12px; }
 .no-data-message {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 300px;
-    color: #666;
-    font-size: 16px;
-    background-color: #f8f9fa;
-    border-radius: 4px;
-    margin-top: 20px;
+  display: flex; justify-content: center; align-items: center;
+  height: 280px; color: #aaa; font-size: 1rem;
+  background: #f9fdf9; border-radius: 10px;
+  border: 2px dashed #d0e8d0;
 }
 
-/* Responsive adjustments */
-@media (max-width: 768px) {
-    .overview-section {
-        padding: 1rem;
-    }
+/* ── loading/error ── */
+.loading { display: flex; justify-content: center; align-items: center; min-height: 200px; color: #666; font-size: 1rem; }
+.error   { color: #c62828; text-align: center; padding: 2rem; background: #fdecea; border-radius: 10px; margin: 1rem 0; }
+.no-data { color: #888; text-align: center; padding: 2rem; background: #fff; border-radius: 10px; }
 
-    .charts-section {
-        grid-template-columns: 1fr;
-    }
-
-    .stats-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-.district-wise-btn {
-    padding: 8px 18px;
-    background-color: #007bff;
-    color: #fff;
-    border: none;
-    border-radius: 6px;
-    font-size: 15px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.2s, box-shadow 0.2s;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-    margin-top: 22px;
-}
-
-.district-wise-btn:hover {
-    background-color: #0056b3;
-}
-
-.district-wise-btn.active {
-    background-color: #fff;
-    color: #007bff;
-    border: 2px solid #007bff;
-}
-
-/* Distribution Sections */
-.domain-distribution-section,
-.slot-distribution-section,
-.mode-distribution-section {
-    margin-bottom: 2.5rem;
-    padding: 1.5rem;
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-}
-
-.domain-distribution-section h2,
-.slot-distribution-section h2,
-.mode-distribution-section h2 {
-    color: #2c3e50;
-    font-size: 1.5rem;
-    margin-bottom: 1.5rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid #f0f0f0;
-}
-
-.distribution-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
-}
-
-.distribution-card {
-    background: #f8f9fa;
-    padding: 1.5rem;
-    border-radius: 10px;
-    transition: all 0.3s ease;
-    border: 1px solid #e9ecef;
-}
-
-.distribution-card:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    border-color: #dee2e6;
-}
-
-.distribution-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.8rem;
-}
-
-.distribution-content h3 {
-    color: #495057;
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin: 0;
-}
-
-.distribution-content p {
-    color: #6c757d;
-    font-size: 0.95rem;
-    margin: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.distribution-content p::before {
-    content: "•";
-    color: #adb5bd;
-}
-
-/* Responsive adjustments for distribution sections */
-@media (max-width: 768px) {
-    .distribution-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .domain-distribution-section,
-    .slot-distribution-section,
-    .mode-distribution-section {
-        padding: 1rem;
-    }
-}
-
-
-.total-count {
-    font-size: 1.2rem;
-    font-weight: 600;
-    color: #333;
-    margin-bottom: 1rem;
-}
-
-@media (max-width: 768px) {
-    .overview-section {
-        padding: 0.75rem;
-    }
-
-    .overview-section h1 {
-        font-size: 1.5rem;
-    }
-
-    .stats-grid {
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-
-    .stat-card {
-        padding: 1rem;
-    }
-
-    .stat-content p {
-        font-size: 1.25rem;
-    }
-
-    .chart-container {
-        padding: 15px;
-    }
-
-    .filters {
-        gap: 10px;
-    }
-
-    .filter-group {
-        min-width: calc(50% - 5px);
-    }
-}
-
-@media (max-width: 480px) {
-    .stats-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .filter-group {
-        min-width: 100%;
-    }
-}
+/* ── Responsive ── */
+@media (max-width: 1024px) { .ov-kpi-grid { grid-template-columns: repeat(2,1fr); } .ov-course-grid { grid-template-columns: repeat(2,1fr); } }
+@media (max-width: 600px)  { .ov-kpi-grid { grid-template-columns: 1fr 1fr; } .ov-course-grid { grid-template-columns: 1fr 1fr; } .overview-section { padding: 14px; } }

--- a/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.js
@@ -2,704 +2,324 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import toast from 'react-hot-toast';
-// import './page.css';
-import { TeamOutlined, CalendarOutlined, UserOutlined, CheckCircleOutlined } from '@ant-design/icons';
-import { FaCheckCircle, FaCalendarAlt, FaClock } from 'react-icons/fa';
-import { 
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
-  PieChart, Pie, Cell, LineChart, Line
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+  Legend, ResponsiveContainer, Cell
 } from 'recharts';
 import './page.css';
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+const GEO_COLORS = ['#014a01','#1b8f2d','#4caf50','#81c784','#a5d6a7','#2e7d32','#388e3c','#43a047','#66bb6a','#c8e6c9'];
+const MARKS_COLORS = { '95–100':'#014a01','90–95':'#1b8f2d','80–89':'#4caf50','70–79':'#f9a825','60–69':'#fb8c00','Below 60':'#e53935' };
+
+const SLOT_OPTS = [
+  { v:'all', l:'All Slots' },
+  { v:'1', l:'Slot 1 — May 11–17' }, { v:'2', l:'Slot 2 — May 18–24' },
+  { v:'3', l:'Slot 3 — May 25–31' }, { v:'4', l:'Slot 4 — Jun 1–7' },
+  { v:'5', l:'Slot 5 — Jun 8–14' }, { v:'6', l:'Slot 6 — Jun 15–21' },
+  { v:'7', l:'Slot 7 — Jun 22–28' }, { v:'8', l:'Slot 8 — Jun 29–Jul 5' },
+  { v:'9', l:'Slot 9 — Jul 6–12' },
+];
 
 export default function Overview() {
-    const { user } = useAuth();
-    const [overviewData, setOverviewData] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const [selectedState, setSelectedState] = useState('');
-    const [selectedDistrict, setSelectedDistrict] = useState('');
-    const [selectedGender, setSelectedGender] = useState('all');
-    const [showDistrictWise, setShowDistrictWise] = useState(false);
-    const [geoSlotFilter, setGeoSlotFilter] = useState('all');
-    const [modeFilter, setModeFilter] = useState('all');
-    const [statsSlotFilter, setStatsSlotFilter] = useState('all');
-    const [statsData, setStatsData] = useState(null);
-    const [statsLoading, setStatsLoading] = useState(false);
-    const [progressStats, setProgressStats] = useState(null);
-    const [selectedDay, setSelectedDay] = useState('all');
-    const [selectedSlot, setSelectedSlot] = useState('all');
-    const [selectedFacultyMentor, setSelectedFacultyMentor] = useState('all');
-    const [selectedStudentLead, setSelectedStudentLead] = useState('all');
-    const [facultyMentors, setFacultyMentors] = useState([]);
-    const [studentLeads, setStudentLeads] = useState([]);
+  const { user } = useAuth();
+  const [overviewData, setOverviewData]   = useState(null);
+  const [loading, setLoading]             = useState(true);
+  const [error, setError]                 = useState(null);
+  const [statsData, setStatsData]         = useState(null);
+  const [statsLoading, setStatsLoading]   = useState(false);
+  const [statsSlotFilter, setStatsSlotFilter] = useState('all');
 
-    const fetchOverviewData = async () => {
-        try {
-            setError(null);
-            setLoading(true);
-            const response = await fetch('/api/dashboard/admin/overview', {
-                method: 'GET',
-                credentials: 'include'
-            });
+  // Geo filters
+  const [selectedState, setSelectedState]     = useState('');
+  const [selectedDistrict, setSelectedDistrict] = useState('');
+  const [selectedGender, setSelectedGender]   = useState('all');
+  const [showDistrictWise, setShowDistrictWise] = useState(false);
+  const [geoSlotFilter, setGeoSlotFilter]     = useState('all');
+  const [modeFilter, setModeFilter]           = useState('all');
 
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || 'Failed to fetch overview data');
-            }
+  const fetchOverviewData = async () => {
+    try {
+      setError(null); setLoading(true);
+      const res = await fetch('/api/dashboard/admin/overview', { credentials: 'include' });
+      if (!res.ok) throw new Error((await res.json()).error || 'Failed to fetch');
+      const data = await res.json();
+      if (data.success) setOverviewData(data.overviewData);
+      else throw new Error(data.error);
+    } catch (err) { setError(err.message); toast.error(err.message); }
+    finally { setLoading(false); }
+  };
 
-            const data = await response.json();
-            if (data.success) {
-                setOverviewData(data.overviewData);
-            } else {
-                throw new Error(data.error || 'Failed to fetch overview data');
-            }
-        } catch (err) {
-            console.error('Error fetching data:', err);
-            setError(err.message);
-            toast.error(err.message);
-        } finally {
-            setLoading(false);
-        }
-    };
+  const fetchStatsData = async (slot) => {
+    try {
+      setStatsLoading(true);
+      const params = slot !== 'all' ? `?slot=${slot}` : '';
+      const res = await fetch(`/api/dashboard/admin/overview${params}`, { credentials: 'include' });
+      const data = await res.json();
+      if (data.success) setStatsData(data.overviewData);
+    } catch (err) { toast.error(err.message); }
+    finally { setStatsLoading(false); }
+  };
 
-    const fetchStatsData = async (slot) => {
-        try {
-            setStatsLoading(true);
-            const params = new URLSearchParams();
-            if (slot !== 'all') {
-                params.append('slot', slot);
-            }
-            const response = await fetch(`/api/dashboard/admin/overview?${params.toString()}`, {
-                method: 'GET',
-                credentials: 'include'
-            });
+  useEffect(() => { if (user?.username) fetchOverviewData(); }, [user]);
+  useEffect(() => { if (user?.username) fetchStatsData(statsSlotFilter); }, [user, statsSlotFilter]);
 
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || 'Failed to fetch statistics');
-            }
+  if (loading) return <div className="loading">Loading dashboard…</div>;
+  if (error)   return <div className="error">{error}</div>;
+  if (!overviewData) return <div className="no-data">No data available</div>;
 
-            const data = await response.json();
-            if (data.success) {
-                setStatsData(data.overviewData);
-            } else {
-                throw new Error(data.error || 'Failed to fetch statistics');
-            }
-        } catch (err) {
-            console.error('Error fetching stats:', err);
-            toast.error(err.message);
-        } finally {
-            setStatsLoading(false);
-        }
-    };
+  const { leadsCount, studentsCount, completedCount, facultyCount,
+          stateStats, districtStats } = overviewData;
 
-    useEffect(() => {
-        if (user?.username) {
-            fetchOverviewData();
-        }
-    }, [user]);
+  const states = [...new Set(stateStats.map(s => s.state))];
+  const districts = selectedState
+    ? [...new Set(districtStats.filter(s => s.state === selectedState).map(s => s.district))]
+    : [];
 
-    useEffect(() => {
-        if (user?.username) {
-            fetchStatsData(statsSlotFilter);
-        }
-    }, [user, statsSlotFilter]);
-
-    useEffect(() => {
-        const fetchProgressStats = async () => {
-            try {
-                // Only proceed if we have a user
-                if (!user?.username) return;
-
-                const params = new URLSearchParams();
-                
-                // Always include the day parameter
-                params.append('day', selectedDay);
-                
-                // Only add other parameters if they are not 'all'
-                if (selectedSlot !== 'all') {
-                    params.append('slot', selectedSlot);
-                }
-                if (selectedFacultyMentor !== 'all') {
-                    params.append('facultyMentorId', selectedFacultyMentor);
-                }
-                if (selectedStudentLead !== 'all') {
-                    params.append('studentLeadId', selectedStudentLead);
-                }
-
-                const queryString = params.toString();
-                const url = `/api/dashboard/admin/progress-stats${queryString ? `?${queryString}` : ''}`;
-
-                const response = await fetch(url, {
-                    method: 'GET',
-                    credentials: 'include'
-                });
-
-                if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(errorData.error || 'Failed to fetch progress stats');
-                }
-
-                const data = await response.json();
-                if (data.success) {
-                    setProgressStats(data.stats);
-                    setFacultyMentors(data.facultyMentors);
-                    setStudentLeads(data.studentLeads);
-                } else {
-                    throw new Error(data.error || 'Failed to fetch progress stats');
-                }
-            } catch (err) {
-                console.error('Error fetching progress stats:', err);
-                toast.error(err.message);
-            }
-        };
-
-        fetchProgressStats();
-    }, [user, selectedDay, selectedSlot, selectedFacultyMentor, selectedStudentLead]);
-
-    if (loading) {
-        return <div className="loading">Loading...</div>;
-    }
-
-    if (error) {
-        return <div className="error">{error}</div>;
-    }
-
-    if (!overviewData) {
-        return <div className="no-data">No overview data available</div>;
-    }
-
-    const { 
-        leadsCount, 
-        studentsCount, 
-        completedCount,
-        facultyCount,
-        verificationStats,
-        attendanceStats,
-        domainStats,
-        modeStats,
-        slotStats,
-        stateStats,
-        districtStats 
-    } = overviewData;
-
-    // Get unique states for filter
-    const states = [...new Set(stateStats.map(stat => stat.state))];
-
-    // Get districts for selected state
-    const districts = selectedState 
-        ? [...new Set(districtStats
-            .filter(stat => stat.state === selectedState)
-            .map(stat => stat.district))]
-        : [];
-
-    // Prepare data for state/district distribution chart
-    const getStateDistributionData = () => {
-        // Helper to filter by slot/mode
-        const filterBySlotMode = (arr) =>
-            arr.filter(stat =>
-                (geoSlotFilter === 'all' || String(stat.slot) === String(geoSlotFilter)) &&
-                (modeFilter === 'all' || stat.mode === modeFilter)
-            );
-
-        if (showDistrictWise && selectedState) {
-            // Show all districts for the selected state (aggregate by district name)
-            const filtered = filterBySlotMode(districtStats.filter(stat => stat.state === selectedState));
-            const districtMap = {};
-            filtered.forEach(stat => {
-                if (!districtMap[stat.district]) {
-                    districtMap[stat.district] = {
-                        value: 0,
-                        male: 0,
-                        female: 0,
-                        other: 0
-                    };
-                }
-                districtMap[stat.district].value += Number(stat.count) || 0;
-                districtMap[stat.district].male += Number(stat.male) || 0;
-                districtMap[stat.district].female += Number(stat.female) || 0;
-                districtMap[stat.district].other += Number(stat.other) || 0;
-            });
-            return Object.entries(districtMap).map(([name, data]) => ({
-                name,
-                value: data.value,
-                male: data.male,
-                female: data.female,
-                other: data.other
-            })).filter(item => item.value > 0);
-        } else if (selectedState && selectedDistrict) {
-            // Aggregate all slot/mode records for the selected district
-            const arr = filterBySlotMode(districtStats.filter(
-                stat => stat.state === selectedState && stat.district === selectedDistrict
-            ));
-            if (!arr.length) return [];
-            const totalMale = arr.reduce((sum, stat) => sum + (Number(stat.male) || 0), 0);
-            const totalFemale = arr.reduce((sum, stat) => sum + (Number(stat.female) || 0), 0);
-            const totalOther = arr.reduce((sum, stat) => sum + (Number(stat.other) || 0), 0);
-            return [
-                { name: 'Male', value: totalMale },
-                { name: 'Female', value: totalFemale },
-                { name: 'Other', value: totalOther }
-            ];
-        } else if (selectedState) {
-            // Aggregate all slot/mode records for the selected state
-            const arr = filterBySlotMode(stateStats.filter(stat => stat.state === selectedState));
-            if (!arr.length) return [];
-            const totalMale = arr.reduce((sum, stat) => sum + (Number(stat.male) || 0), 0);
-            const totalFemale = arr.reduce((sum, stat) => sum + (Number(stat.female) || 0), 0);
-            const totalOther = arr.reduce((sum, stat) => sum + (Number(stat.other) || 0), 0);
-            return [
-                { name: 'Male', value: totalMale },
-                { name: 'Female', value: totalFemale },
-                { name: 'Other', value: totalOther }
-            ];
-        } else {
-            // Show all states (aggregate by state name)
-            const filtered = filterBySlotMode(stateStats);
-            const stateMap = {};
-            filtered.forEach(stat => {
-                if (!stateMap[stat.state]) {
-                    stateMap[stat.state] = {
-                        value: 0,
-                        male: 0,
-                        female: 0,
-                        other: 0
-                    };
-                }
-                stateMap[stat.state].value += Number(stat.count) || 0;
-                stateMap[stat.state].male += Number(stat.male) || 0;
-                stateMap[stat.state].female += Number(stat.female) || 0;
-                stateMap[stat.state].other += Number(stat.other) || 0;
-            });
-            return Object.entries(stateMap).map(([name, data]) => ({
-                name,
-                value: data.value,
-                male: data.male,
-                female: data.female,
-                other: data.other
-            })).filter(item => item.value > 0);
-        }
-    };
-
-    const stateDistributionData = getStateDistributionData();
-
-    // Filter data based on selected gender (only for gender view)
-    const filteredStateDistributionData = (showDistrictWise && selectedState)
-        ? stateDistributionData
-        : (selectedGender === 'all' 
-            ? stateDistributionData 
-            : stateDistributionData.map(item => ({
-                name: item.name,
-                value: item[selectedGender.toLowerCase()] || 0
-              })));
-
-    // Calculate total for current filter
-    const totalFiltered = filteredStateDistributionData.reduce((sum, item) => sum + item.value, 0);
-
-    // Prepare data for charts
-    const completionData = [
-        { name: 'Completed', value: completedCount },
-        { name: 'In Progress', value: studentsCount - completedCount }
-    ];
-
-    const attendanceData = [
-        { name: 'Present', value: attendanceStats.total },
-        { name: 'Absent', value: studentsCount - attendanceStats.total }
-    ];
-
-    const dailyProgressData = [
-        { name: 'Day 1', completed: verificationStats.day1, pending: studentsCount - verificationStats.day1 },
-        { name: 'Day 2', completed: verificationStats.day2, pending: studentsCount - verificationStats.day2 },
-        { name: 'Day 3', completed: verificationStats.day3, pending: studentsCount - verificationStats.day3 },
-        { name: 'Day 4', completed: verificationStats.day4, pending: studentsCount - verificationStats.day4 },
-        { name: 'Day 5', completed: verificationStats.day5, pending: studentsCount - verificationStats.day5 },
-        { name: 'Day 6', completed: verificationStats.day6, pending: studentsCount - verificationStats.day6 },
-        { name: 'Day 7', completed: verificationStats.day7, pending: studentsCount - verificationStats.day7 }
-    ];
-
-    return (
-        <div className="overview-section">
-            <h1>Admin Dashboard Overview</h1>
-            <p className="role-text">Administrator</p>
-            
-            <div className="stats-grid">
-                <div className="stat-card">
-                    <div className="stat-content">
-                        <div>
-                            <h3>Total Students</h3>
-                            <p>{studentsCount}</p>
-                        </div>
-                        <TeamOutlined className="stat-icon" />
-                    </div>
-                </div>
-
-                <div className="stat-card">
-                    <div className="stat-content">
-                        <div>
-                            <h3>Completed Students</h3>
-                            <p>{completedCount}</p>
-                        </div>
-                        <CheckCircleOutlined className="stat-icon" />
-                    </div>
-                </div>
-
-                <div className="stat-card">
-                    <div className="stat-content">
-                        <div>
-                            <h3>Student Leads</h3>
-                            <p>{leadsCount}</p>
-                        </div>
-                        <UserOutlined className="stat-icon" />
-                    </div>
-                </div>
-
-                <div className="stat-card">
-                    <div className="stat-content">
-                        <div>
-                            <h3>Faculty Mentors</h3>
-                            <p>{facultyCount}</p>
-                        </div>
-                        <UserOutlined className="stat-icon" />
-                    </div>
-                </div>
-            </div>
-
-            {/* Geographical Distribution at the top, full width */}
-            <div className="geo-section">
-                <div className="chart-container">
-                    <h2>Geographical Distribution</h2>
-                    <div className="filters">
-                        <div className="filter-group">
-                            <label htmlFor="state">State</label>
-                            <select
-                                id="state"
-                                value={selectedState}
-                                onChange={(e) => {
-                                    setSelectedState(e.target.value);
-                                    setSelectedDistrict('');
-                                    setShowDistrictWise(false);
-                                }}
-                            >
-                                <option value="">All States</option>
-                                {states.map(state => (
-                                    <option key={state} value={state}>{state}</option>
-                                ))}
-                            </select>
-                        </div>
-
-                        {selectedState && (
-                            <>
-                                <div className="filter-group">
-                                    <label htmlFor="district">District</label>
-                                    <select
-                                        id="district"
-                                        value={selectedDistrict}
-                                        onChange={(e) => setSelectedDistrict(e.target.value)}
-                                        disabled={showDistrictWise}
-                                    >
-                                        <option value="">All Districts</option>
-                                        {districts.map(district => (
-                                            <option key={district} value={district}>{district}</option>
-                                        ))}
-                                    </select>
-                                </div>
-                                <div className="filter-group" style={{ alignSelf: 'flex-end' }}>
-                                    <button
-                                        type="button"
-                                        className={`district-wise-btn${showDistrictWise ? ' active' : ''}`}
-                                        onClick={() => setShowDistrictWise(v => !v)}
-                                    >
-                                        {showDistrictWise ? 'Show Gender Wise' : 'Show District Wise'}
-                                    </button>
-                                </div>
-                            </>
-                        )}
-
-                        <div className="filter-group">
-                            <label htmlFor="gender">Gender</label>
-                            <select
-                                id="gender"
-                                value={selectedGender}
-                                onChange={(e) => setSelectedGender(e.target.value)}
-                                disabled={showDistrictWise}
-                            >
-                                <option value="all">All</option>
-                                <option value="male">Male</option>
-                                <option value="female">Female</option>
-                                <option value="other">Other</option>
-                            </select>
-                        </div>
-                        <div className="filter-group">
-                            <label htmlFor="geoSlot">Slot</label>
-                            <select
-                                id="geoSlot"
-                                value={geoSlotFilter}
-                                onChange={e => setGeoSlotFilter(e.target.value)}
-                            >
-                                <option value="all">All Slots</option>
-                                <option value="1">Slot 1 — May 11–17</option>
-                                <option value="2">Slot 2 — May 18–24</option>
-                                <option value="3">Slot 3 — May 25–31</option>
-                                <option value="4">Slot 4 — Jun 1–7</option>
-                                <option value="5">Slot 5 — Jun 8–14</option>
-                                <option value="6">Slot 6 — Jun 15–21</option>
-                                <option value="7">Slot 7 — Jun 22–28</option>
-                                <option value="8">Slot 8 — Jun 29–Jul 5</option>
-                                <option value="9">Slot 9 — Jul 6–12</option>
-                            </select>
-                        </div>
-                        <div className="filter-group">
-                            <label htmlFor="mode">Mode</label>
-                            <select
-                                id="mode"
-                                value={modeFilter}
-                                onChange={e => setModeFilter(e.target.value)}
-                            >
-                                <option value="all">All Modes</option>
-                                <option value="Remote">Remote</option>
-                                <option value="Incampus">Incampus</option>
-                                <option value="InVillage">InVillage</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div className="total-count">Total: {totalFiltered}</div>
-                    {filteredStateDistributionData.length > 0 ? (
-                        <div style={{ width: '100%', height: 400 }}>
-                            <ResponsiveContainer width="100%" height={350}>
-                                <BarChart
-                                    data={filteredStateDistributionData}
-                                    // margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
-                                >
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis 
-                                        dataKey="name" 
-                                        tick={{ fontSize: 10 }} 
-                                        angle={-15} 
-                                        textAnchor="end"
-                                        interval={0}
-                                    />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#8884d8">
-                                        {filteredStateDistributionData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Bar>
-                                </BarChart>
-                            </ResponsiveContainer>
-                        </div>
-                    ) : (
-                        <div className="no-data-message">
-                            No data available for the selected filters
-                        </div>
-                    )}
-                </div>
-            </div>
-
-            {/* Other charts in a row below */}
-            {/* <div className="charts-section charts-row">
-                <div className="chart-container">
-                    <h2>Completion Status</h2>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <PieChart>
-                            <Pie
-                                data={completionData}
-                                cx="50%"
-                                cy="50%"
-                                labelLine={false}
-                                outerRadius={80}
-                                fill="#8884d8"
-                                dataKey="value"
-                                label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-                            >
-                                {completionData.map((entry, index) => (
-                                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                ))}
-                            </Pie>
-                            <Tooltip />
-                            <Legend />
-                        </PieChart>
-                    </ResponsiveContainer>
-                </div>
-
-                <div className="chart-container">
-                    <h2>Attendance Status</h2>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={attendanceData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="value" fill="#8884d8" />
-                        </BarChart>
-                    </ResponsiveContainer>
-                </div>
-
-                <div className="chart-container">
-                    <h2>Daily Progress</h2>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <LineChart data={dailyProgressData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Line type="monotone" dataKey="completed" stroke="#8884d8" />
-                            <Line type="monotone" dataKey="pending" stroke="#82ca9d" />
-                        </LineChart>
-                    </ResponsiveContainer>
-                </div>
-            </div> */}
-
-           
-
-            {/* <div className="slot-distribution-section">
-                <h2>Slot Distribution</h2>
-                <div className="distribution-grid">
-                    {slotStats.map((slot, index) => (
-                        <div key={index} className="distribution-card">
-                            <div className="distribution-content">
-                                <div>
-                                    <h3>Slot {slot.slot}</h3>
-                                    <p>Total: {slot.count}</p>
-                                    <p>Completed: {slot.completed}</p>
-                                </div>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </div>
-            
-            <div className="mode-distribution-section">
-                <h2>Mode Distribution</h2>
-                <div className="distribution-grid">
-                    {modeStats.map((mode, index) => (
-                        <div key={index} className="distribution-card">
-                            <div className="distribution-content">
-                                <div>
-                                    <h3>{mode.mode}</h3>
-                                    <p>Total: {mode.count}</p>
-                                    <p>Completed: {mode.completed}</p>
-                                </div>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </div>
-            
-            <div className="domain-distribution-section">
-                <h2>Domain Distribution</h2>
-                <div className="distribution-grid">
-                    {domainStats.map((domain, index) => (
-                        <div key={index} className="distribution-card">
-                            <div className="distribution-content">
-                                <div>
-                                    <h3>{domain.selectedDomain}</h3>
-                                    <p>Total: {domain.count}</p>
-                                    <p>Completed: {domain.completed}</p>
-                                </div>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </div> */}
-
-            <div className="progress-stats-section">
-                <h2>Course Statistics</h2>
-                <div className="progress-filters">
-                    <div className="filter-group">
-                        <label htmlFor="statsSlot">Slot</label>
-                        <select 
-                            id="statsSlot"
-                            value={statsSlotFilter} 
-                            onChange={(e) => setStatsSlotFilter(e.target.value)}
-                            className="filter-select"
-                        >
-                            <option value="all">All Slots</option>
-                            <option value="1">Slot 1 — May 11–17</option>
-                            <option value="2">Slot 2 — May 18–24</option>
-                            <option value="3">Slot 3 — May 25–31</option>
-                            <option value="4">Slot 4 — Jun 1–7</option>
-                            <option value="5">Slot 5 — Jun 8–14</option>
-                            <option value="6">Slot 6 — Jun 15–21</option>
-                            <option value="7">Slot 7 — Jun 22–28</option>
-                            <option value="8">Slot 8 — Jun 29–Jul 5</option>
-                            <option value="9">Slot 9 — Jul 6–12</option>
-                        </select>
-                    </div>
-                </div>
-                
-                {statsLoading ? (
-                    <div className="loading">Loading statistics...</div>
-                ) : error ? (
-                    <div className="error">{error}</div>
-                ) : (
-                    <>
-                        <div className="progress-stats-grid">
-                            <div className="progress-stat-card">
-                                <h3>Total Registered</h3>
-                                <p>{statsData?.studentsCount || 0}</p>
-                            </div>
-                            <div className="progress-stat-card">
-                                <h3>Total Participated</h3>
-                                <p>{statsData?.totalParticipated || 0}</p>
-                            </div>
-                            {/* <div className="progress-stat-card">
-                                <h3>Total Completed</h3>
-                                <p>{statsData?.completedCount || 0}</p>
-                            </div> */}
-                            <div className="progress-stat-card">
-                                <h3>Total Passed</h3>
-                                <p>{statsData?.totalPassed || 0}</p>
-                            </div>
-                            <div className="progress-stat-card">
-                                <h3>Total Failed</h3>
-                                <p>{statsData?.totalFailed || 0}</p>
-                            </div>
-                        </div>
-
-                        <div className="marks-distribution-section">
-                            <h2>Marks Distribution</h2>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart
-                                    data={[
-                                        { range: '95-100', count: statsData?.marksDistribution?.['95_to_100'] || 0 },
-                                        { range: '90-95', count: statsData?.marksDistribution?.['90_to_95'] || 0 },
-                                        { range: '80-89', count: statsData?.marksDistribution?.['80_to_89'] || 0 },
-                                        { range: '70-79', count: statsData?.marksDistribution?.['70_to_79'] || 0 },
-                                        { range: '60-69', count: statsData?.marksDistribution?.['60_to_69'] || 0 },
-                                        { range: 'Below 60', count: statsData?.marksDistribution?.['below_60'] || 0 }
-                                    ]}
-                                    margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
-                                >
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="range" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#8884d8" name="Students">
-                                        <Cell fill="#4CAF50" />
-                                        <Cell fill="#8BC34A" />
-                                        <Cell fill="#CDDC39" />
-                                        <Cell fill="#FFEB3B" />
-                                        <Cell fill="#FFC107" />
-                                        <Cell fill="#FF9800" />
-                                        <Cell fill="#F44336" />
-                                    </Bar>
-                                </BarChart>
-                            </ResponsiveContainer>
-                        </div>
-                    </>
-                )}
-            </div>
-
-            {/* <p className="beta-note">
-                Note: This is a beta version. If you experience any issues or discrepancies, please report them to SAC Department.
-            </p> */}
-        </div>
+  // ── Geo data builder ────────────────────────────────────────────────────────
+  const filterBySlotMode = arr =>
+    arr.filter(s =>
+      (geoSlotFilter === 'all' || String(s.slot) === geoSlotFilter) &&
+      (modeFilter    === 'all' || s.mode === modeFilter)
     );
+
+  const buildGeoData = () => {
+    if (showDistrictWise && selectedState) {
+      const filtered = filterBySlotMode(districtStats.filter(s => s.state === selectedState));
+      const map = {};
+      filtered.forEach(s => {
+        if (!map[s.district]) map[s.district] = { value:0, male:0, female:0, other:0 };
+        map[s.district].value  += Number(s.count)  || 0;
+        map[s.district].male   += Number(s.male)   || 0;
+        map[s.district].female += Number(s.female) || 0;
+        map[s.district].other  += Number(s.other)  || 0;
+      });
+      return Object.entries(map).map(([name, d]) => ({ name, ...d })).filter(r => r.value > 0);
+    }
+    if (selectedState && selectedDistrict) {
+      const arr = filterBySlotMode(districtStats.filter(s => s.state === selectedState && s.district === selectedDistrict));
+      if (!arr.length) return [];
+      return [
+        { name:'Male',   value: arr.reduce((a,s) => a + (Number(s.male)||0),   0) },
+        { name:'Female', value: arr.reduce((a,s) => a + (Number(s.female)||0), 0) },
+        { name:'Other',  value: arr.reduce((a,s) => a + (Number(s.other)||0),  0) },
+      ];
+    }
+    if (selectedState) {
+      const arr = filterBySlotMode(stateStats.filter(s => s.state === selectedState));
+      if (!arr.length) return [];
+      return [
+        { name:'Male',   value: arr.reduce((a,s) => a + (Number(s.male)||0),   0) },
+        { name:'Female', value: arr.reduce((a,s) => a + (Number(s.female)||0), 0) },
+        { name:'Other',  value: arr.reduce((a,s) => a + (Number(s.other)||0),  0) },
+      ];
+    }
+    // All states
+    const filtered = filterBySlotMode(stateStats);
+    const map = {};
+    filtered.forEach(s => {
+      if (!map[s.state]) map[s.state] = { value:0, male:0, female:0, other:0 };
+      map[s.state].value  += Number(s.count)  || 0;
+      map[s.state].male   += Number(s.male)   || 0;
+      map[s.state].female += Number(s.female) || 0;
+      map[s.state].other  += Number(s.other)  || 0;
+    });
+    return Object.entries(map).map(([name, d]) => ({ name, ...d })).filter(r => r.value > 0);
+  };
+
+  const geoData = buildGeoData();
+  const filteredGeoData = (showDistrictWise && selectedState)
+    ? geoData
+    : selectedGender === 'all'
+      ? geoData
+      : geoData.map(r => ({ name: r.name, value: r[selectedGender.toLowerCase()] || 0 }));
+
+  const totalFiltered = filteredGeoData.reduce((a, r) => a + r.value, 0);
+
+  // ── Marks data ──────────────────────────────────────────────────────────────
+  const marksData = [
+    { range:'95–100', count: statsData?.marksDistribution?.['95_to_100'] || 0, color: MARKS_COLORS['95–100'] },
+    { range:'90–95',  count: statsData?.marksDistribution?.['90_to_95']  || 0, color: MARKS_COLORS['90–95'] },
+    { range:'80–89',  count: statsData?.marksDistribution?.['80_to_89']  || 0, color: MARKS_COLORS['80–89'] },
+    { range:'70–79',  count: statsData?.marksDistribution?.['70_to_79']  || 0, color: MARKS_COLORS['70–79'] },
+    { range:'60–69',  count: statsData?.marksDistribution?.['60_to_69']  || 0, color: MARKS_COLORS['60–69'] },
+    { range:'Below 60', count: statsData?.marksDistribution?.['below_60'] || 0, color: MARKS_COLORS['Below 60'] },
+  ];
+  const maxMarks = Math.max(...marksData.map(r => r.count), 1);
+
+  const kpiCards = [
+    { label:'Total Students',    value: studentsCount,   icon:'👨‍🎓', color:'#014a01', bg:'#e6f4ea' },
+    { label:'Completed',         value: completedCount,  icon:'✅',   color:'#1565c0', bg:'#e3f2fd' },
+    { label:'Student Leads',     value: leadsCount,      icon:'🌟',   color:'#6a1b9a', bg:'#f3e5f5' },
+    { label:'Faculty Mentors',   value: facultyCount,    icon:'👩‍🏫', color:'#e65100', bg:'#fff3e0' },
+  ];
+
+  return (
+    <div className="overview-section">
+      {/* ── Header ── */}
+      <div className="ov-header">
+        <div className="ov-header-left">
+          <h1>Admin Dashboard Overview</h1>
+          <p>Real-time data · Last refreshed just now</p>
+        </div>
+        <button className="ov-refresh-btn" onClick={() => { fetchOverviewData(); fetchStatsData(statsSlotFilter); }}>
+          🔄 Refresh
+        </button>
+      </div>
+
+      {/* ── KPI Cards ── */}
+      <div className="ov-kpi-grid">
+        {kpiCards.map(k => (
+          <div key={k.label} className="ov-kpi-card" style={{ '--kpi-color': k.color, '--kpi-bg': k.bg }}>
+            <div className="ov-kpi-icon">{k.icon}</div>
+            <div className="ov-kpi-info">
+              <h4>{k.label}</h4>
+              <p>{k.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Geographical Distribution ── */}
+      <div className="ov-section-card">
+        <h2 className="ov-section-title"><span>🗺️</span> Geographical Distribution</h2>
+        <div className="ov-filters">
+          <div className="ov-filter-group">
+            <label>State</label>
+            <select value={selectedState} onChange={e => { setSelectedState(e.target.value); setSelectedDistrict(''); setShowDistrictWise(false); }}>
+              <option value="">All States</option>
+              {states.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
+          {selectedState && (
+            <>
+              <div className="ov-filter-group">
+                <label>District</label>
+                <select value={selectedDistrict} onChange={e => setSelectedDistrict(e.target.value)} disabled={showDistrictWise}>
+                  <option value="">All Districts</option>
+                  {districts.map(d => <option key={d} value={d}>{d}</option>)}
+                </select>
+              </div>
+              <div className="ov-filter-group" style={{ alignSelf:'flex-end' }}>
+                <label style={{ opacity:0 }}>_</label>
+                <button className={`ov-toggle-btn${showDistrictWise ? ' active' : ''}`}
+                  onClick={() => setShowDistrictWise(v => !v)}>
+                  {showDistrictWise ? '📍 District View ON' : '📍 Show District-Wise'}
+                </button>
+              </div>
+            </>
+          )}
+          <div className="ov-filter-group">
+            <label>Gender</label>
+            <select value={selectedGender} onChange={e => setSelectedGender(e.target.value)} disabled={showDistrictWise}>
+              <option value="all">All</option>
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div className="ov-filter-group">
+            <label>Slot</label>
+            <select value={geoSlotFilter} onChange={e => setGeoSlotFilter(e.target.value)}>
+              {SLOT_OPTS.map(o => <option key={o.v} value={o.v}>{o.l}</option>)}
+            </select>
+          </div>
+          <div className="ov-filter-group">
+            <label>Mode</label>
+            <select value={modeFilter} onChange={e => setModeFilter(e.target.value)}>
+              <option value="all">All Modes</option>
+              <option value="Remote">Remote</option>
+              <option value="Incampus">In Campus</option>
+              <option value="InVillage">In Village</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="ov-total-badge">📊 Total: {totalFiltered} students</div>
+
+        {filteredGeoData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={340}>
+            <BarChart data={filteredGeoData} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e8f5e9" />
+              <XAxis dataKey="name" tick={{ fontSize: 11, fill:'#555', fontWeight:600 }} angle={-15} textAnchor="end" interval={0} />
+              <YAxis tick={{ fontSize: 11, fill:'#888' }} />
+              <Tooltip
+                contentStyle={{ background:'#fff', border:'1.5px solid #b7dfb7', borderRadius:10, boxShadow:'0 4px 16px rgba(0,0,0,0.1)' }}
+                labelStyle={{ fontWeight:700, color:'#014a01' }}
+              />
+              <Legend />
+              <Bar dataKey="value" name="Students" radius={[6,6,0,0]}>
+                {filteredGeoData.map((_, i) => (
+                  <Cell key={i} fill={GEO_COLORS[i % GEO_COLORS.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="no-data-message">No data for selected filters</div>
+        )}
+      </div>
+
+      {/* ── Course Statistics ── */}
+      <div className="ov-section-card">
+        <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', flexWrap:'wrap', gap:12 }}>
+          <h2 className="ov-section-title" style={{ margin:0, borderBottom:'none', paddingBottom:0 }}>
+            <span>📈</span> Course Statistics
+          </h2>
+          <div className="ov-filter-group" style={{ minWidth:200, maxWidth:260 }}>
+            <label>Filter by Slot</label>
+            <select value={statsSlotFilter} onChange={e => setStatsSlotFilter(e.target.value)}>
+              {SLOT_OPTS.map(o => <option key={o.v} value={o.v}>{o.l}</option>)}
+            </select>
+          </div>
+        </div>
+        <div style={{ borderBottom:'2px solid #f0f7f0', marginBottom:20, marginTop:14 }} />
+
+        {statsLoading ? (
+          <div className="loading">Loading statistics…</div>
+        ) : (
+          <>
+            <div className="ov-course-grid">
+              <div className="ov-course-card">
+                <h4>Total Registered</h4>
+                <p>{statsData?.studentsCount || 0}</p>
+              </div>
+              <div className="ov-course-card blue">
+                <h4>Total Participated</h4>
+                <p>{statsData?.totalParticipated || 0}</p>
+              </div>
+              <div className="ov-course-card">
+                <h4>Total Passed</h4>
+                <p>{statsData?.totalPassed || 0}</p>
+              </div>
+              <div className="ov-course-card red">
+                <h4>Total Failed</h4>
+                <p>{statsData?.totalFailed || 0}</p>
+              </div>
+            </div>
+
+            {/* Marks distribution — custom horizontal bars */}
+            <h3 style={{ fontWeight:700, color:'#012a01', fontSize:'0.95rem', margin:'0 0 16px', display:'flex', alignItems:'center', gap:8 }}>
+              📊 Marks Distribution
+            </h3>
+            <div className="ov-marks-bar-row">
+              {marksData.map(({ range, count, color }) => {
+                const pct = Math.round((count / maxMarks) * 100);
+                return (
+                  <div key={range} className="ov-marks-row">
+                    <span className="ov-marks-label">{range}</span>
+                    <div className="ov-marks-bar-wrap">
+                      <div className="ov-marks-bar-fill" style={{ width: `${pct}%`, background: color, minWidth: count > 0 ? 40 : 0 }}>
+                        {count > 0 && count}
+                      </div>
+                    </div>
+                    <span className="ov-marks-count">{count}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/my-app/src/app/(pages)/dashboard/admin/_components/problemStatements/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/problemStatements/page.js
@@ -14,8 +14,9 @@ export default function ProblemStatements() {
     const [filters, setFilters] = useState({ domain: '', state: '', district: '' });
     const [currentPage, setCurrentPage] = useState(1);
     const [itemsPerPage] = useState(10);
-    const [activeTab, setActiveTab] = useState('table'); // 'table' | 'analytics'
+    const [activeTab, setActiveTab] = useState('table'); // 'table' | 'analytics' | 'not-submitted'
     const [expandedDomain, setExpandedDomain] = useState(null);
+    const [nsSearch, setNsSearch] = useState('');
 
 
 
@@ -140,8 +141,8 @@ export default function ProblemStatements() {
             </div>
 
             {/* Tab switcher */}
-            <div style={{ display: 'flex', gap: '10px', marginBottom: '20px' }}>
-                {['table', 'analytics'].map(tab => (
+            <div style={{ display: 'flex', gap: '10px', marginBottom: '20px', flexWrap: 'wrap' }}>
+                {['table', 'analytics', 'not-submitted'].map(tab => (
                     <button
                         key={tab}
                         onClick={() => setActiveTab(tab)}
@@ -153,7 +154,7 @@ export default function ProblemStatements() {
                             textTransform: 'capitalize'
                         }}
                     >
-                        {tab === 'analytics' ? '📊 Analytics' : '📋 Student Table'}
+                        {tab === 'analytics' ? '📊 Analytics' : tab === 'not-submitted' ? `❌ Not Submitted (${data.stats.notSubmitted})` : '📋 Student Table'}
                     </button>
                 ))}
             </div>
@@ -308,6 +309,63 @@ export default function ProblemStatements() {
                         </div>
                     </div>
                 </>
+            )}
+            {/* ─── NOT SUBMITTED TAB ─── */}
+            {activeTab === 'not-submitted' && (
+                <div>
+                    <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:14, flexWrap:'wrap', gap:8 }}>
+                        <h2 style={{ color:'#d4380d', fontWeight:700, margin:0 }}>❌ Students Who Have Not Selected a Problem Statement</h2>
+                        <span style={{ background:'#fff1f0', border:'1px solid #ffa39e', color:'#d4380d', padding:'4px 14px', borderRadius:20, fontWeight:700, fontSize:'0.85rem' }}>
+                            {data.notSubmittedList?.length || 0} students pending
+                        </span>
+                    </div>
+                    <input
+                        type="text"
+                        placeholder="Search by ID, name, branch or domain…"
+                        value={nsSearch}
+                        onChange={e => setNsSearch(e.target.value)}
+                        style={{ width:'100%', padding:'9px 13px', borderRadius:8, border:'1.5px solid #ccc', fontSize:'0.92rem', marginBottom:14, boxSizing:'border-box' }}
+                    />
+                    <div className="table-container">
+                        <table className="problem-statements-table">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Student ID</th>
+                                    <th>Name</th>
+                                    <th>Branch</th>
+                                    <th>Slot</th>
+                                    <th>Mode</th>
+                                    <th>Domain Selected</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {(data.notSubmittedList || [])
+                                    .filter(s => !nsSearch ||
+                                        s.username?.toLowerCase().includes(nsSearch.toLowerCase()) ||
+                                        s.name?.toLowerCase().includes(nsSearch.toLowerCase()) ||
+                                        s.branch?.toLowerCase().includes(nsSearch.toLowerCase()) ||
+                                        s.selectedDomain?.toLowerCase().includes(nsSearch.toLowerCase())
+                                    )
+                                    .map((s, i) => (
+                                        <tr key={s.username}>
+                                            <td style={{ color:'#999', fontSize:'0.82rem' }}>{i + 1}</td>
+                                            <td><strong>{s.username}</strong></td>
+                                            <td>{s.name}</td>
+                                            <td>{s.branch}</td>
+                                            <td>Slot {s.slot}</td>
+                                            <td>{s.mode}</td>
+                                            <td>{s.selectedDomain || '—'}</td>
+                                        </tr>
+                                    ))
+                                }
+                                {(data.notSubmittedList || []).length === 0 && (
+                                    <tr><td colSpan={7} style={{ textAlign:'center', padding:32, color:'#52c41a', fontWeight:700 }}>🎉 All students have submitted their problem statements!</td></tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             )}
         </div>
     );

--- a/my-app/src/app/(pages)/dashboard/admin/_components/slotControl/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/slotControl/page.js
@@ -1,0 +1,157 @@
+'use client';
+import { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
+
+const SLOT_DATES = {
+  1: 'May 11–17',   2: 'May 18–24',  3: 'May 25–31',
+  4: 'Jun 1–7',     5: 'Jun 8–14',   6: 'Jun 15–21',
+  7: 'Jun 22–28',   8: 'Jun 29–Jul 5', 9: 'Jul 6–12',
+};
+
+const S = {
+  wrap:    { padding: 28, maxWidth: 900, margin: '0 auto', fontFamily: 'Inter, sans-serif' },
+  header:  { marginBottom: 28 },
+  h2:      { fontSize: '1.5rem', fontWeight: 800, color: '#012a01', margin: '0 0 6px', letterSpacing: '-0.02em' },
+  sub:     { color: '#666', fontSize: '0.88rem', margin: 0 },
+  grid:    { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: 16 },
+  card:    {
+    background: '#fff', borderRadius: 16, padding: '20px 22px',
+    boxShadow: '0 2px 12px rgba(0,0,0,0.08)', border: '1.5px solid #e8f5e9',
+    display: 'flex', flexDirection: 'column', gap: 14,
+    transition: 'all 0.2s',
+  },
+  cardOn:  { borderColor: '#014a01', boxShadow: '0 4px 20px rgba(1,74,1,0.18)' },
+  topRow:  { display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
+  slotNum: { fontSize: '1.1rem', fontWeight: 800, color: '#012a01' },
+  date:    { fontSize: '0.78rem', color: '#888', fontWeight: 500, marginTop: 2 },
+  badge:   { display: 'inline-block', padding: '3px 12px', borderRadius: 20, fontSize: '0.75rem', fontWeight: 700 },
+  badgeOn: { background: '#e6f4ea', color: '#014a01' },
+  badgeOff:{ background: '#f5f5f5', color: '#aaa' },
+
+  // Toggle switch
+  switchWrap: { position: 'relative', width: 52, height: 28, cursor: 'pointer', flexShrink: 0 },
+  switchTrack: (on) => ({
+    width: '100%', height: '100%', borderRadius: 14,
+    background: on ? '#014a01' : '#d0d0d0',
+    transition: 'background 0.25s',
+    border: 'none', outline: 'none', cursor: 'pointer',
+    position: 'relative', display: 'block',
+  }),
+  switchThumb: (on) => ({
+    position: 'absolute', top: 3, left: on ? 26 : 3,
+    width: 22, height: 22, borderRadius: '50%',
+    background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,0.2)',
+    transition: 'left 0.25s',
+    pointerEvents: 'none',
+  }),
+
+  info: { fontSize: '0.8rem', color: '#666', lineHeight: 1.5 },
+  infoOn: { color: '#2e7d32' },
+
+  loading: { textAlign: 'center', padding: 40, color: '#888' },
+};
+
+export default function SlotControl() {
+  const [slots, setSlots]       = useState([]);
+  const [loading, setLoading]   = useState(true);
+  const [toggling, setToggling] = useState({}); // { slotNum: true/false }
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/dashboard/admin/slot-control');
+        const json = await res.json();
+        if (json.success) setSlots(json.slots);
+        else toast.error('Failed to load slot states');
+      } catch { toast.error('Network error'); }
+      finally { setLoading(false); }
+    })();
+  }, []);
+
+  const toggle = async (slot, currentEnabled) => {
+    const newVal = !currentEnabled;
+    setToggling(p => ({ ...p, [slot]: true }));
+    try {
+      const res = await fetch('/api/dashboard/admin/slot-control', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slot, enabled: newVal }),
+      });
+      const json = await res.json();
+      if (json.success) {
+        setSlots(prev => prev.map(s => s.slot === slot ? { ...s, enabled: newVal ? 1 : 0 } : s));
+        toast.success(`Slot ${slot} ${newVal ? 'enabled ✅' : 'disabled 🔒'}`);
+      } else {
+        toast.error(json.error || 'Failed to update');
+      }
+    } catch { toast.error('Network error'); }
+    finally { setToggling(p => ({ ...p, [slot]: false })); }
+  };
+
+  if (loading) return <div style={S.loading}>Loading slot states…</div>;
+
+  const enabledCount = slots.filter(s => s.enabled).length;
+
+  return (
+    <div style={S.wrap}>
+      <div style={S.header}>
+        <h2 style={S.h2}>🎛️ Slot Control</h2>
+        <p style={S.sub}>
+          Toggle each slot on or off. Students see the full dashboard only when their slot is enabled.
+          &nbsp;<strong>{enabledCount} / 9</strong> slots currently active.
+        </p>
+      </div>
+
+      {/* Summary pill row */}
+      <div style={{ display:'flex', gap:8, flexWrap:'wrap', marginBottom:24 }}>
+        {slots.map(s => (
+          <span key={s.slot} style={{
+            padding:'4px 12px', borderRadius:20, fontSize:'0.75rem', fontWeight:700,
+            background: s.enabled ? '#014a01' : '#f0f0f0',
+            color: s.enabled ? '#fff' : '#aaa',
+            border: `1.5px solid ${s.enabled ? '#014a01' : '#e0e0e0'}`,
+          }}>Slot {s.slot}</span>
+        ))}
+      </div>
+
+      <div style={S.grid}>
+        {slots.map(({ slot, enabled }) => {
+          const on = Boolean(enabled);
+          const busy = toggling[slot];
+          return (
+            <div key={slot} style={{ ...S.card, ...(on ? S.cardOn : {}) }}>
+              <div style={S.topRow}>
+                <div>
+                  <div style={S.slotNum}>Slot {slot}</div>
+                  <div style={S.date}>📅 {SLOT_DATES[slot]}</div>
+                </div>
+                {/* Toggle */}
+                <button
+                  style={S.switchTrack(on)}
+                  onClick={() => !busy && toggle(slot, on)}
+                  disabled={busy}
+                  title={on ? 'Click to disable' : 'Click to enable'}
+                >
+                  <span style={S.switchThumb(on)} />
+                </button>
+              </div>
+
+              <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center' }}>
+                <span style={{ ...S.badge, ...(on ? S.badgeOn : S.badgeOff) }}>
+                  {on ? '✅ Active' : '🔒 Locked'}
+                </span>
+                {busy && <span style={{ fontSize:'0.75rem', color:'#888' }}>Updating…</span>}
+              </div>
+
+              <div style={{ ...S.info, ...(on ? S.infoOn : {}) }}>
+                {on
+                  ? 'Students in this slot can see all dashboard sections and submit their work.'
+                  : 'Students only see Overview, Profile, Change Password and their Mentor (if assigned).'}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/app/(pages)/dashboard/admin/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/page.js
@@ -25,6 +25,8 @@ import VerifyCertificates from './_components/verifyCertificates/page';
 import SFinalProfile from './_components/sfinal/page';
 import ProblemStatements from './_components/problemStatements/page';
 import ActivityLogs from './_components/activityLogs/page';
+import DailyTasksViewer from '../studentLead/_components/dailyTasksViewer/page';
+import SlotControl from './_components/slotControl/page';
 
 
 export default function AdminDashboard() {
@@ -239,6 +241,20 @@ export default function AdminDashboard() {
           </button>
 
           <button
+            className={`sidebar-item ${activeSection === 'slot-control' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('slot-control')}
+          >
+            <span className="item-label">Slot Control</span>
+          </button>
+
+          <button
+            className={`sidebar-item ${activeSection === 'daily-tasks' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('daily-tasks')}
+          >
+            <span className="item-label">Daily Tasks</span>
+          </button>
+
+          <button
             className={`sidebar-item ${activeSection === 'reset-password' ? 'active' : ''}`}
             onClick={() => handleSectionClick('reset-password')}
           >
@@ -330,6 +346,8 @@ export default function AdminDashboard() {
            activeSection === 'supply-final' ? <SFinalProfile /> :
            activeSection === 'problem-statements' ? <ProblemStatements /> :
            activeSection === 'activity-logs' ? <ActivityLogs /> :
+           activeSection === 'slot-control' ? <SlotControl /> :
+           activeSection === 'daily-tasks' ? <DailyTasksViewer /> :
            <ChangePassword />}
         </main>
       </div>

--- a/my-app/src/app/(pages)/dashboard/facultyMentor/page.js
+++ b/my-app/src/app/(pages)/dashboard/facultyMentor/page.js
@@ -12,6 +12,7 @@ import Leads from './_components/leads/page';
 import CompletedStudents from './_components/completedStudents/page';
 import FinalReports from './_components/finalReports/page';
 import SurveyResponses from '../studentLead/_components/surveyResponses/page';
+import DailyTasksViewer from '../studentLead/_components/dailyTasksViewer/page';
 
 export default function FacultyMentorDashboard() {
   const { user, isLoading, isAuthenticated } = useAuth();
@@ -72,6 +73,12 @@ export default function FacultyMentorDashboard() {
             <span className="item-label">Final Reports</span>
           </button>
           <button
+            className={`sidebar-item ${activeSection === 'daily-tasks' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('daily-tasks')}
+          >
+            <span className="item-label">Daily Tasks</span>
+          </button>
+          <button
             className={`sidebar-item ${activeSection === 'survey-responses' ? 'active' : ''}`}
             onClick={() => handleSectionClick('survey-responses')}
           >
@@ -92,6 +99,7 @@ export default function FacultyMentorDashboard() {
            activeSection === 'leads' ? <Leads user={user} /> :
            activeSection === 'completed-students' ? <CompletedStudents user={user} /> :
            activeSection === 'final-reports' ? <FinalReports user={user} /> :
+           activeSection === 'daily-tasks' ? <DailyTasksViewer /> :
            activeSection === 'survey-responses' ? <SurveyResponses user={user} /> :
            <ChangePassword user={user} />}
         </main>

--- a/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/dailyTasks.css
+++ b/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/dailyTasks.css
@@ -1,0 +1,209 @@
+.dt-wrap { padding: 24px; max-width: 860px; margin: 0 auto; }
+.dt-header { margin-bottom: 20px; }
+.dt-header h2 { font-size: 1.4rem; font-weight: 700; color: #014a01; margin: 0 0 4px; }
+.dt-header p { color: #555; font-size: 0.9rem; margin: 0; }
+
+.dt-day-select-row { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
+.dt-day-select-row label { font-weight: 600; color: #014a01; font-size: 0.95rem; }
+.dt-day-select {
+  padding: 9px 16px; border-radius: 8px; border: 2px solid #014a01;
+  font-size: 0.95rem; color: #014a01; background: #fff; cursor: pointer;
+  font-weight: 600; outline: none;
+}
+.dt-day-select:focus { box-shadow: 0 0 0 3px rgba(1,74,1,0.15); }
+
+.dt-badge {
+  font-size: 0.78rem; font-weight: 700; padding: 3px 10px; border-radius: 20px;
+  background: #e6f4ea; color: #014a01; border: 1px solid #b7dfb7;
+}
+.dt-badge.saved { background: #014a01; color: #fff; border-color: #014a01; }
+
+/* Day card */
+.dt-card {
+  background: #fff; border-radius: 14px; border: 1.5px solid #d0e8d0;
+  box-shadow: 0 2px 12px rgba(1,74,1,0.07); overflow: hidden;
+}
+.dt-card-head {
+  background: linear-gradient(90deg, #014a01 0%, #1a7a1a 100%);
+  padding: 16px 22px; display: flex; align-items: center; gap: 12px;
+}
+.dt-card-head .day-icon { font-size: 1.6rem; }
+.dt-card-head h3 { color: #fff; font-size: 1.05rem; font-weight: 700; margin: 0; }
+.dt-card-head p { color: rgba(255,255,255,0.82); font-size: 0.84rem; margin: 3px 0 0; }
+.dt-card-body { padding: 22px; }
+
+/* Textarea */
+.dt-textarea-wrap { margin-bottom: 16px; }
+.dt-textarea-wrap label { display: block; font-weight: 600; color: #333; margin-bottom: 6px; font-size: 0.9rem; }
+.dt-textarea {
+  width: 100%; min-height: 160px; padding: 12px 14px;
+  border: 1.5px solid #ccc; border-radius: 8px; font-size: 0.95rem;
+  resize: vertical; font-family: inherit; line-height: 1.6; transition: border 0.2s;
+  box-sizing: border-box;
+}
+.dt-textarea:focus { border-color: #014a01; outline: none; box-shadow: 0 0 0 3px rgba(1,74,1,0.1); }
+.dt-word-count { font-size: 0.8rem; color: #888; text-align: right; margin-top: 4px; }
+.dt-word-count.warn { color: #d97706; font-weight: 600; }
+.dt-word-count.ok { color: #014a01; font-weight: 600; }
+
+/* Person tabs */
+.dt-persons-label { font-weight: 600; color: #333; font-size: 0.9rem; margin-bottom: 8px; }
+.dt-person-tabs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.dt-person-btn {
+  padding: 7px 16px; border-radius: 20px; border: 1.5px solid #ccc;
+  background: #f5f5f5; cursor: pointer; font-size: 0.88rem; font-weight: 600;
+  color: #555; transition: all 0.18s;
+}
+.dt-person-btn:hover { border-color: #014a01; color: #014a01; background: #e6f4ea; }
+.dt-person-btn.active { background: #014a01; color: #fff; border-color: #014a01; }
+.dt-person-btn.filled { border-color: #4caf50; color: #2e7d32; background: #f0faf0; }
+.dt-person-btn.active.filled { background: #014a01; color: #fff; }
+
+/* Name input */
+.dt-name-wrap { margin-bottom: 16px; }
+.dt-name-wrap label { display: block; font-weight: 600; color: #333; margin-bottom: 6px; font-size: 0.9rem; }
+.dt-name-input {
+  width: 100%; max-width: 360px; padding: 9px 13px;
+  border: 1.5px solid #ccc; border-radius: 8px; font-size: 0.95rem;
+  font-family: inherit; transition: border 0.2s; box-sizing: border-box;
+}
+.dt-name-input:focus { border-color: #014a01; outline: none; box-shadow: 0 0 0 3px rgba(1,74,1,0.1); }
+
+/* Stakeholder info banner */
+.dt-sh-banner {
+  background: #f0f7f0; border: 1.5px solid #b7dfb7; border-radius: 10px;
+  padding: 12px 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 10px;
+}
+.dt-sh-banner .sh-tag {
+  background: #014a01; color: #fff; font-size: 0.78rem; font-weight: 700;
+  padding: 3px 10px; border-radius: 12px; white-space: nowrap;
+}
+.dt-sh-banner p { margin: 0; font-size: 0.88rem; color: #444; }
+
+/* Questions list */
+.dt-questions { list-style: none; padding: 0; margin: 0 0 16px; display: flex; flex-direction: column; gap: 12px; }
+.dt-q-item { background: #fafafa; border: 1px solid #e8e8e8; border-radius: 10px; padding: 14px 16px; }
+.dt-q-text { font-size: 0.9rem; color: #333; margin-bottom: 10px; line-height: 1.5; font-weight: 500; }
+.dt-q-btns { display: flex; gap: 8px; }
+.dt-q-btn {
+  padding: 5px 18px; border-radius: 20px; border: 1.5px solid #ccc;
+  cursor: pointer; font-size: 0.85rem; font-weight: 600; background: #fff; transition: all 0.15s;
+}
+.dt-q-btn.yes.sel { background: #014a01; color: #fff; border-color: #014a01; }
+.dt-q-btn.no.sel  { background: #c62828; color: #fff; border-color: #c62828; }
+.dt-q-btn:hover:not(.sel) { border-color: #014a01; color: #014a01; }
+
+/* Data analysis */
+.dt-analysis-info {
+  background: #fff8e1; border: 1.5px solid #ffe082; border-radius: 10px;
+  padding: 14px 16px; margin-bottom: 18px; font-size: 0.88rem; color: #6c5700; line-height: 1.6;
+}
+.dt-analysis-info strong { color: #014a01; }
+.dt-sh-analysis { margin-bottom: 20px; }
+.dt-sh-analysis h4 { font-size: 0.95rem; font-weight: 700; color: #014a01; margin: 0 0 10px; }
+.dt-person-analysis { margin-bottom: 14px; }
+.dt-person-analysis h5 { font-size: 0.88rem; font-weight: 600; color: #333; margin: 0 0 8px; }
+.dt-q-stat { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-size: 0.82rem; color: #555; }
+.dt-q-stat .q-label { flex: 1; line-height: 1.4; }
+.dt-bar-wrap { width: 120px; background: #eee; border-radius: 6px; height: 8px; }
+.dt-bar-yes { height: 8px; border-radius: 6px; background: #014a01; transition: width 0.4s; }
+.dt-pct { font-weight: 700; color: #014a01; min-width: 38px; text-align: right; }
+
+.dt-severity-box {
+  background: #f0f7f0; border: 1.5px solid #b7dfb7; border-radius: 10px;
+  padding: 14px 16px; margin-top: 16px;
+}
+.dt-severity-box h4 { color: #014a01; font-size: 0.95rem; font-weight: 700; margin: 0 0 10px; }
+.dt-severity-item { margin-bottom: 10px; font-size: 0.88rem; }
+.dt-severity-item strong { color: #333; }
+.dt-severity-label { display: inline-block; padding: 2px 10px; border-radius: 12px; font-weight: 700; font-size: 0.78rem; margin-left: 8px; }
+.dt-severity-label.high { background: #fdecea; color: #c62828; }
+.dt-severity-label.medium { background: #fff8e1; color: #e65100; }
+.dt-severity-label.low { background: #e8f5e9; color: #2e7d32; }
+
+/* Link input */
+.dt-link-section { margin-bottom: 18px; }
+.dt-link-section label { display: block; font-weight: 600; color: #333; margin-bottom: 6px; font-size: 0.9rem; }
+.dt-link-section p { font-size: 0.82rem; color: #888; margin: 0 0 8px; line-height: 1.5; }
+.dt-link-input {
+  width: 100%; padding: 9px 13px; border: 1.5px solid #ccc; border-radius: 8px;
+  font-size: 0.93rem; font-family: inherit; transition: border 0.2s; box-sizing: border-box;
+}
+.dt-link-input:focus { border-color: #014a01; outline: none; box-shadow: 0 0 0 3px rgba(1,74,1,0.1); }
+.dt-warning-box {
+  background: #fdecea; border: 1.5px solid #f5c6c6; border-radius: 8px;
+  padding: 10px 14px; margin-bottom: 14px; font-size: 0.84rem; color: #c62828; font-weight: 600;
+}
+
+/* ── Day timeline ── */
+.dt-timeline { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 24px; }
+.dt-day-pill {
+  display: flex; align-items: center; gap: 6px; padding: 7px 14px;
+  border-radius: 22px; border: 1.5px solid #ccc; background: #f5f5f5;
+  cursor: pointer; font-size: 0.85rem; font-weight: 600; color: #555;
+  transition: all 0.18s; white-space: nowrap;
+}
+.dt-day-pill:hover:not(.locked):not(.missed) { border-color: #014a01; color: #014a01; background: #e6f4ea; }
+.dt-day-pill.active { background: #014a01; color: #fff; border-color: #014a01; }
+.dt-day-pill.submitted { border-color: #4caf50; color: #2e7d32; background: #f0faf0; }
+.dt-day-pill.active.submitted { background: #014a01; color: #fff; }
+.dt-day-pill.locked { background: #f0f0f0; color: #aaa; border-color: #ddd; cursor: not-allowed; }
+.dt-day-pill.missed { background: #fdecea; color: #c62828; border-color: #f5c6c6; cursor: not-allowed; }
+.dt-day-pill.upcoming { background: #f5f5f5; color: #999; border-color: #e0e0e0; cursor: not-allowed; }
+.dt-pill-icon { font-size: 1rem; }
+
+/* ── Timer bar ── */
+.dt-timer-bar {
+  display: flex; align-items: center; gap: 10px;
+  background: #fff8e1; border: 1.5px solid #ffe082; border-radius: 10px;
+  padding: 10px 16px; margin-bottom: 18px; flex-wrap: wrap;
+}
+.dt-timer-label { font-size: 0.82rem; color: #6c5700; font-weight: 600; flex-shrink: 0; }
+.dt-timer-count { font-size: 1rem; font-weight: 800; color: #014a01; letter-spacing: 0.04em; }
+.dt-timer-count.urgent { color: #c62828; animation: timerPulse 1s infinite; }
+.dt-timer-date { font-size: 0.78rem; color: #888; margin-left: auto; }
+@keyframes timerPulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+
+/* ── Lock overlay ── */
+.dt-locked-overlay {
+  text-align: center; padding: 40px 20px;
+  background: #f8f8f8; border-radius: 10px;
+}
+.dt-locked-overlay .lock-icon { font-size: 3rem; margin-bottom: 12px; }
+.dt-locked-overlay h3 { color: #555; font-size: 1.1rem; margin-bottom: 8px; }
+.dt-locked-overlay p { color: #888; font-size: 0.88rem; line-height: 1.6; }
+.dt-locked-overlay.missed-lock { background: #fdecea; }
+.dt-locked-overlay.missed-lock h3 { color: #c62828; }
+
+/* ── Day date badge in header ── */
+.dt-day-date { font-size: 0.8rem; color: rgba(255,255,255,0.75); margin-top: 2px; }
+
+
+/* Info box */
+.dt-info-box {
+  background: #f0f7f0; border: 1.5px solid #b7dfb7; border-radius: 10px;
+  padding: 14px 16px; font-size: 0.88rem; color: #444; line-height: 1.7;
+}
+.dt-info-box h4 { color: #014a01; font-weight: 700; margin: 0 0 8px; font-size: 0.95rem; }
+.dt-info-box ul { margin: 6px 0 0 16px; padding: 0; }
+.dt-info-box li { margin-bottom: 4px; }
+
+/* Save button row */
+.dt-save-row { margin-top: 20px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+.dt-save-btn {
+  padding: 10px 28px; background: #014a01; color: #fff; border: none;
+  border-radius: 8px; font-size: 0.95rem; font-weight: 700; cursor: pointer; transition: background 0.2s;
+}
+.dt-save-btn:hover:not(:disabled) { background: #023a01; }
+.dt-save-btn:disabled { background: #a5c8a5; cursor: not-allowed; }
+.dt-save-msg { font-size: 0.88rem; }
+.dt-save-msg.ok { color: #014a01; font-weight: 600; }
+.dt-save-msg.err { color: #c62828; font-weight: 600; }
+
+/* No PS warning */
+.dt-no-ps {
+  text-align: center; padding: 40px 20px; background: #fff8e1;
+  border: 2px solid #ffe082; border-radius: 12px;
+}
+.dt-no-ps h3 { color: #856404; margin-bottom: 8px; }
+.dt-no-ps p { color: #6c5700; font-size: 0.9rem; }

--- a/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/page.js
+++ b/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/page.js
@@ -1,0 +1,538 @@
+'use client';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { surveyData as SURVEY } from './surveyDataShared';
+import './dailyTasks.css';
+
+/* ── Slot start dates (IST midnight) ── */
+const SLOT_START = {
+  1: new Date('2026-05-11T00:00:00+05:30'),
+  2: new Date('2026-05-18T00:00:00+05:30'),
+  3: new Date('2026-05-25T00:00:00+05:30'),
+  4: new Date('2026-06-01T00:00:00+05:30'),
+  5: new Date('2026-06-08T00:00:00+05:30'),
+  6: new Date('2026-06-15T00:00:00+05:30'),
+  7: new Date('2026-06-22T00:00:00+05:30'),
+  8: new Date('2026-06-29T00:00:00+05:30'),
+  9: new Date('2026-07-06T00:00:00+05:30'),
+};
+
+/** 11:59:59 PM IST on the Nth day of the slot */
+function dayDeadline(slot, dayNum) {
+  const start = SLOT_START[slot];
+  if (!start) return null;
+  const d = new Date(start);
+  d.setDate(d.getDate() + (dayNum - 1));
+  // 23:59:59.999 in IST = UTC+5:30
+  // We store as absolute epoch so it's device-clock-independent when compared with serverNow()
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+/* Offset between server IST epoch and device clock — set once on mount */
+let _serverOffset = 0;   // ms
+function serverNow() { return Date.now() + _serverOffset; }
+
+function dayLabel(slot, dayNum) {
+  const dl = dayDeadline(slot, dayNum);
+  if (!dl) return '';
+  return dl.toLocaleDateString('en-IN', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Status: 'upcoming' | 'open' | 'submitted' | 'missed' | 'locked'
+ */
+function getDayStatus(dayNum, slot, saved) {
+  if (!slot || !SLOT_START[slot]) return 'upcoming';
+  const dl = dayDeadline(slot, dayNum);
+  const now = serverNow();   // ← server-authoritative IST time
+  const isSubmitted = !!saved[dayNum];
+  if (isSubmitted) return 'submitted';
+  if (dl && now > dl.getTime()) return 'missed';
+  if (dayNum === 1) {
+    return now >= SLOT_START[slot].getTime() ? 'open' : 'upcoming';
+  }
+  const prevStatus = getDayStatus(dayNum - 1, slot, saved);
+  if (prevStatus === 'missed' || prevStatus === 'locked') return 'locked';
+  if (prevStatus !== 'submitted') return 'upcoming';
+  return 'open';
+}
+
+function pillClass(st, active) {
+  let c = 'dt-day-pill';
+  if (active) c += ' active';
+  if (st === 'submitted') c += ' submitted';
+  if (st === 'locked')    c += ' locked';
+  if (st === 'missed')    c += ' missed';
+  if (st === 'upcoming')  c += ' upcoming';
+  return c;
+}
+function pillIcon(st) {
+  return st === 'submitted' ? '✓' : st === 'locked' ? '🔒' : st === 'missed' ? '❌' : st === 'upcoming' ? '⏳' : '▶';
+}
+function wc(text) { return text.trim() === '' ? 0 : text.trim().split(/\s+/).length; }
+
+const DAY_META = [
+  { day:1, icon:'📋', title:'Day 1 – Problem Statement Understanding', subtitle:'Write your inference and analysis (minimum 100 words)' },
+  { day:2, icon:'🤝', title:'Day 2 – Stakeholder 1 Survey (8 Persons)',  subtitle:'Interview 8 people from the 1st stakeholder group' },
+  { day:3, icon:'🤝', title:'Day 3 – Stakeholder 2 Survey (3 Persons)',  subtitle:'Interview 3 people from the 2nd stakeholder group' },
+  { day:4, icon:'🤝', title:'Day 4 – Stakeholder 3 Survey (3 Persons)',  subtitle:'Interview 3 people from the 3rd stakeholder group' },
+  { day:5, icon:'📊', title:'Day 5 – Data Analysis',                     subtitle:'Count responses, calculate percentages & identify insights' },
+  { day:6, icon:'📸', title:'Day 6 – Intervention Activity',             subtitle:'Upload photo documentation from Days 2, 3 & 4' },
+  { day:7, icon:'📹', title:'Day 7 – Documentation & Presentation',      subtitle:'Submit case study report, YouTube video & LinkedIn post' },
+];
+
+/* ── Timer bar component ── */
+function TimerBar({ deadline }) {
+  const [tick, setTick] = useState('');
+  useEffect(() => {
+    const update = () => {
+      const diff = deadline - serverNow();   // ← server time
+      if (diff <= 0) { setTick('Submission closed'); return; }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setTick(`${h}h ${m}m ${s}s`);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [deadline]);
+  const urgent = (deadline - serverNow()) < 3 * 3600000 && (deadline - serverNow()) > 0;
+  return (
+    <div className="dt-timer-bar">
+      <span className="dt-timer-label">⏰ Submission window closes in:</span>
+      <span className={`dt-timer-count${urgent ? ' urgent' : ''}`}>{tick}</span>
+      <span className="dt-timer-date">
+        Deadline: {deadline.toLocaleString('en-IN', { day:'numeric', month:'short', hour:'2-digit', minute:'2-digit', hour12:true })}
+      </span>
+    </div>
+  );
+}
+
+/* ── Lock overlay ── */
+function LockedView({ status, dayNum, slot }) {
+  const dl = slot ? dayDeadline(slot, dayNum) : null;
+  const dateStr = dl ? dl.toLocaleDateString('en-IN', { day:'numeric', month:'long' }) : '';
+  if (status === 'missed') return (
+    <div className="dt-locked-overlay missed-lock">
+      <div className="lock-icon">❌</div>
+      <h3>Submission Window Closed</h3>
+      <p>The deadline for Day {dayNum} ({dateStr}) passed without a submission.<br/>This day is permanently locked.</p>
+    </div>
+  );
+  if (status === 'locked') return (
+    <div className="dt-locked-overlay missed-lock">
+      <div className="lock-icon">🔒</div>
+      <h3>Day {dayNum} Locked</h3>
+      <p>A previous day was not submitted in time. All subsequent days are locked.<br/>Contact your mentor if you believe this is an error.</p>
+    </div>
+  );
+  return (
+    <div className="dt-locked-overlay">
+      <div className="lock-icon">⏳</div>
+      <h3>Day {dayNum} Not Yet Available</h3>
+      <p>{dayNum === 1
+        ? `This day opens on ${dateStr} when your slot begins.`
+        : `Complete and submit Day ${dayNum - 1} first to unlock this day.`}
+      </p>
+    </div>
+  );
+}
+
+/* ── Main component ── */
+export default function DailyTasks({ studentData }) {
+  const [activeDay, setActiveDay] = useState(null);
+  const [saved, setSaved]     = useState({});
+  const [draft, setDraft]     = useState({});
+  const [saving, setSaving]   = useState(false);
+  const [msg, setMsg]         = useState('');
+  const [msgType, setMsgType] = useState('ok');
+
+  const ps     = studentData?.problemStatementData?.problem_statement || null;
+  const slot   = studentData?.slot || null;
+  const survey = ps ? (SURVEY[ps] || null) : null;
+
+  useEffect(() => {
+    (async () => {
+      try {
+        // 1. Fetch server time first to anchor all deadline checks
+        const timeRes = await fetch('/api/time');
+        const timeJson = await timeRes.json();
+        _serverOffset = timeJson.ts - Date.now();  // may be +/- a few ms
+
+        // 2. Fetch saved tasks
+        const res  = await fetch('/api/dashboard/student/daily-tasks');
+        const json = await res.json();
+        const tasks = (json.success && json.tasks) ? json.tasks : {};
+        setSaved(tasks);
+        const firstOpen = [1,2,3,4,5,6,7].find(d => {
+          const st = getDayStatus(d, slot, tasks);
+          return st === 'open' || st === 'submitted';
+        });
+        setActiveDay(firstOpen || 1);
+      } catch { setActiveDay(1); }
+    })();
+  }, [slot]);
+
+  const dayData = useCallback((day) => ({
+    ...(saved[day]?.data || {}),
+    ...(draft[day]  || {}),
+  }), [saved, draft]);
+
+  const setDayField = (day, field, value) => {
+    setDraft(prev => ({ ...prev, [day]: { ...(prev[day] || {}), [field]: value } }));
+    setMsg('');
+  };
+
+  const handleSave = async () => {
+    const data = dayData(activeDay);
+    if (activeDay === 1 && wc(data.inference || '') < 100) {
+      setMsg(`Need at least 100 words (currently ${wc(data.inference||'')})`);
+      setMsgType('err'); return;
+    }
+    setSaving(true);
+    try {
+      const res  = await fetch('/api/dashboard/student/daily-tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ day: activeDay, data }),
+      });
+      const json = await res.json();
+      if (json.success) {
+        setSaved(prev => ({ ...prev, [activeDay]: { data } }));
+        setDraft(prev => { const n = { ...prev }; delete n[activeDay]; return n; });
+        setMsg('✓ Saved successfully!'); setMsgType('ok');
+      } else { setMsg(json.error || 'Save failed'); setMsgType('err'); }
+    } catch { setMsg('Network error'); setMsgType('err'); }
+    finally { setSaving(false); }
+  };
+
+  if (!ps) return (
+    <div className="dt-wrap">
+      <div className="dt-no-ps">
+        <h3>⚠️ Problem Statement Not Selected</h3>
+        <p>Please select your Problem Statement in the Overview section first.</p>
+      </div>
+    </div>
+  );
+
+  if (activeDay === null) return <div className="dt-wrap"><p style={{color:'#888'}}>Loading…</p></div>;
+
+  const statuses    = Object.fromEntries([1,2,3,4,5,6,7].map(d => [d, getDayStatus(d, slot, saved)]));
+  const meta        = DAY_META[activeDay - 1];
+  const activeStatus = statuses[activeDay];
+  const isSaved     = activeStatus === 'submitted' && !draft[activeDay];
+  const deadline    = slot ? dayDeadline(slot, activeDay) : null;
+  const isEditable  = activeStatus === 'open';
+
+  return (
+    <div className="dt-wrap">
+      <div className="dt-header">
+        <h2>📅 Daily Tasks</h2>
+        <p>Problem Statement: <strong>{ps}</strong>
+          {slot && <span style={{marginLeft:8,fontSize:'0.8rem',color:'#888'}}>· Slot {slot}</span>}
+        </p>
+      </div>
+
+      {/* Timeline pills */}
+      <div className="dt-timeline">
+        {DAY_META.map(m => {
+          const st = statuses[m.day];
+          const canClick = st === 'open' || st === 'submitted';
+          return (
+            <button
+              key={m.day}
+              className={pillClass(st, activeDay === m.day)}
+              onClick={() => canClick && setActiveDay(m.day)}
+              title={`${slot ? dayLabel(slot, m.day) + ' · ' : ''}${st}`}
+            >
+              <span className="dt-pill-icon">{pillIcon(st)}</span>
+              Day {m.day}
+              {slot && <span style={{fontSize:'0.72rem',opacity:0.8}}> · {dayLabel(slot, m.day)}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Countdown timer */}
+      {activeStatus === 'open' && deadline && <TimerBar deadline={deadline} />}
+
+      {/* Day card */}
+      <div className="dt-card">
+        <div className="dt-card-head">
+          <span className="day-icon">{meta.icon}</span>
+          <div>
+            <h3>{meta.title}</h3>
+            <p>{meta.subtitle}</p>
+            {slot && <p className="dt-day-date">📅 {dayLabel(slot, activeDay)} · Closes 11:59 PM IST</p>}
+          </div>
+        </div>
+        <div className="dt-card-body">
+          {(activeStatus === 'locked' || activeStatus === 'missed' || activeStatus === 'upcoming')
+            ? <LockedView status={activeStatus} dayNum={activeDay} slot={slot} />
+            : (
+              <>
+                {activeDay === 1 && <Day1 data={dayData(1)} onChange={(f,v) => setDayField(1,f,v)} ps={ps} readOnly={isSaved} />}
+                {activeDay === 2 && <DaySurvey day={2} personCount={8} stakeholderIdx={0} survey={survey} data={dayData(2)} onChange={(f,v) => setDayField(2,f,v)} readOnly={isSaved} />}
+                {activeDay === 3 && <DaySurvey day={3} personCount={3} stakeholderIdx={1} survey={survey} data={dayData(3)} onChange={(f,v) => setDayField(3,f,v)} readOnly={isSaved} />}
+                {activeDay === 4 && <DaySurvey day={4} personCount={3} stakeholderIdx={2} survey={survey} data={dayData(4)} onChange={(f,v) => setDayField(4,f,v)} readOnly={isSaved} />}
+                {activeDay === 5 && <Day5 saved={saved} survey={survey} />}
+                {activeDay === 6 && <Day6 data={dayData(6)} onChange={(f,v) => setDayField(6,f,v)} readOnly={isSaved} />}
+                {activeDay === 7 && <Day7 data={dayData(7)} onChange={(f,v) => setDayField(7,f,v)} readOnly={isSaved} />}
+
+                {activeDay !== 5 && (
+                  <div className="dt-save-row">
+                    <button className="dt-save-btn" onClick={handleSave} disabled={saving || isSaved || !isEditable}>
+                      {saving ? 'Saving…' : isSaved ? '✓ Submitted' : '💾 Save & Submit'}
+                    </button>
+                    {isSaved && <span style={{fontSize:'0.82rem',color:'#888'}}>Submitted — view only</span>}
+                    {msg && <span className={`dt-save-msg ${msgType}`}>{msg}</span>}
+                  </div>
+                )}
+              </>
+            )
+          }
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Day 1 ── */
+function Day1({ data, onChange, ps, readOnly }) {
+  const text  = data.inference || '';
+  const words = wc(text);
+  return (
+    <div>
+      <div className="dt-info-box" style={{ marginBottom: 16 }}>
+        <h4>Task: Problem Statement Understanding</h4>
+        <ul>
+          <li>Read your problem statement carefully: <strong>{ps}</strong></li>
+          <li>Research using internet, books, or local observation</li>
+          <li>Write your inference and analysis — <strong>minimum 100 words</strong></li>
+          <li>Cover: what the problem is, why it exists, who is affected, and possible root causes</li>
+        </ul>
+      </div>
+      <div className="dt-textarea-wrap">
+        <label htmlFor="day1-inference">Your Inference &amp; Analysis</label>
+        <textarea
+          id="day1-inference" className="dt-textarea"
+          placeholder="Write your understanding of the problem statement here…"
+          value={text} readOnly={readOnly}
+          onChange={e => !readOnly && onChange('inference', e.target.value)}
+          style={readOnly ? { background:'#f9f9f9', color:'#555' } : {}}
+        />
+        <p className={`dt-word-count ${words >= 100 ? 'ok' : words > 60 ? 'warn' : ''}`}>
+          {words} / 100 words minimum {words >= 100 ? '✓' : ''}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ── Days 2/3/4 – Survey ── */
+function DaySurvey({ day, personCount, stakeholderIdx, survey, data, onChange, readOnly }) {
+  const [activePerson, setActivePerson] = useState(1);
+  if (!survey) return <div className="dt-info-box"><h4>Survey data not available</h4><p>No questions found for your problem statement. Contact admin.</p></div>;
+
+  const sh = survey[stakeholderIdx];
+  if (!sh) return <p>Stakeholder not found.</p>;
+
+  const persons = Array.from({ length: personCount }, (_, i) => i + 1);
+  const pk = (p) => `p${p}`;
+  const pd = (p) => data[pk(p)] || { name: '', answers: {} };
+  const isFilled = (p) => { const d = pd(p); return d.name?.trim() && Object.keys(d.answers||{}).length > 0; };
+
+  const setField = (p, field, value) => {
+    if (readOnly) return;
+    const cur = data[pk(p)] || { name:'', answers:{} };
+    onChange(pk(p), { ...cur, [field]: value });
+  };
+  const setAnswer = (p, qi, val) => {
+    if (readOnly) return;
+    const cur = data[pk(p)] || { name:'', answers:{} };
+    onChange(pk(p), { ...cur, answers: { ...(cur.answers||{}), [qi]: val } });
+  };
+
+  const cur = pd(activePerson);
+  return (
+    <div>
+      <div className="dt-sh-banner">
+        <span className="sh-tag">{sh.stakeholder}</span>
+        <p>Interview {personCount} people. Enter each person&apos;s name and record Yes/No responses.</p>
+      </div>
+      <p className="dt-persons-label">Select Person:</p>
+      <div className="dt-person-tabs">
+        {persons.map(p => (
+          <button key={p} className={`dt-person-btn ${activePerson===p?'active':''} ${isFilled(p)?'filled':''}`}
+            onClick={() => setActivePerson(p)}>
+            Person {p} {isFilled(p) ? '✓' : ''}
+          </button>
+        ))}
+      </div>
+      <div className="dt-name-wrap">
+        <label htmlFor={`n-d${day}-p${activePerson}`}>Name of Person {activePerson}</label>
+        <input id={`n-d${day}-p${activePerson}`} type="text" className="dt-name-input"
+          placeholder="Enter interviewee's name" value={cur.name||''} readOnly={readOnly}
+          onChange={e => setField(activePerson, 'name', e.target.value)}
+          style={readOnly ? {background:'#f9f9f9'} : {}} />
+      </div>
+      <ul className="dt-questions">
+        {sh.questions.map((q, qi) => {
+          const ans = cur.answers?.[qi];
+          return (
+            <li key={qi} className="dt-q-item">
+              <p className="dt-q-text">{qi+1}. {q}</p>
+              <div className="dt-q-btns">
+                <button className={`dt-q-btn yes ${ans==='Yes'?'sel':''}`}
+                  onClick={() => setAnswer(activePerson, qi, 'Yes')} disabled={readOnly}>Yes</button>
+                <button className={`dt-q-btn no ${ans==='No'?'sel':''}`}
+                  onClick={() => setAnswer(activePerson, qi, 'No')} disabled={readOnly}>No</button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+/* ── Day 5 – Analysis ── */
+function Day5({ saved, survey }) {
+  if (!survey) return <div className="dt-info-box"><h4>Survey data unavailable</h4></div>;
+  const analyses = [2,3,4].map(day => {
+    const sh = survey[day-2];
+    if (!sh) return null;
+    const dd = saved[day]?.data || {};
+    const persons = Object.keys(dd).filter(k => k.startsWith('p'));
+    const stats = sh.questions.map((q, qi) => {
+      let yes=0, no=0;
+      persons.forEach(pk => { const a = dd[pk]?.answers?.[qi]; if (a==='Yes') yes++; else if (a==='No') no++; });
+      const total = yes+no;
+      return { q, yes, no, total, yesPct: total>0 ? Math.round((yes/total)*100) : 0 };
+    });
+    const avg = stats.length ? Math.round(stats.reduce((a,s)=>a+s.yesPct,0)/stats.length) : 0;
+    return { sh, day, persons, stats, avg, severity: avg>=70?'high':avg>=40?'medium':'low' };
+  }).filter(Boolean);
+
+  if (analyses.every(a => a.persons.length===0)) return (
+    <div className="dt-info-box">
+      <h4>📊 Data Analysis</h4>
+      <p>No survey data yet. Complete Days 2, 3, and 4 first.</p>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="dt-analysis-info">
+        <strong>Auto-generated from Days 2, 3 &amp; 4.</strong> Review Yes% per question, identify severity, root causes, and affected groups.
+      </div>
+      {analyses.map(({ sh, day, persons, stats, avg, severity }) => (
+        <div key={day} className="dt-sh-analysis">
+          <h4>Day {day} – {sh.stakeholder} ({persons.length} persons)</h4>
+          {persons.length===0
+            ? <p style={{color:'#888',fontSize:'0.88rem'}}>No data for this day yet.</p>
+            : stats.map(({ q, yes, no, yesPct }, qi) => (
+              <div key={qi} className="dt-q-stat">
+                <span className="q-label">{qi+1}. {q.replace(' (Yes/No)','')}</span>
+                <div className="dt-bar-wrap"><div className="dt-bar-yes" style={{width:`${yesPct}%`}} /></div>
+                <span className="dt-pct">{yesPct}% Yes</span>
+                <span style={{fontSize:'0.78rem',color:'#888'}}>({yes}Y/{no}N)</span>
+              </div>
+            ))
+          }
+          {persons.length>0 && (
+            <div className="dt-severity-box">
+              <h4>📌 Insights for {sh.stakeholder}</h4>
+              <div className="dt-severity-item">
+                <strong>Severity:</strong>
+                <span className={`dt-severity-label ${severity}`}>
+                  {severity==='high'?'🔴 High':severity==='medium'?'🟡 Medium':'🟢 Low'}
+                </span> ({avg}% avg Yes)
+              </div>
+              <div className="dt-severity-item">
+                <strong>Root Causes:</strong>{' '}
+                {stats.filter(s=>s.yesPct>=60).length>0
+                  ? `Top issues: ${stats.filter(s=>s.yesPct>=60).map(s=>`"${s.q.split('?')[0]}"`).join(', ')}.`
+                  : 'No dominant issues in this group.'}
+              </div>
+              <div className="dt-severity-item"><strong>Affected Group:</strong> {sh.stakeholder} — {persons.length} individuals.</div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Day 6 ── */
+function Day6({ data, onChange, readOnly }) {
+  const ro = { background: readOnly ? '#f9f9f9' : undefined };
+  return (
+    <div>
+      <div className="dt-info-box" style={{marginBottom:18}}>
+        <h4>Task: Intervention Activity Documentation</h4>
+        <ul>
+          <li>Compile all photos from Days 2, 3, and 4 stakeholder interactions</li>
+          <li>Add <strong>date</strong> and <strong>description</strong> for each photo</li>
+          <li>Upload to Google Doc / Drive folder — <strong>must be publicly viewable</strong></li>
+        </ul>
+      </div>
+      <div className="dt-warning-box">⚠️ Set sharing to <strong>&quot;Anyone with the link can view&quot;</strong>. Private links will NOT be evaluated.</div>
+      <div className="dt-link-section">
+        <label htmlFor="d6-link">Google Drive / Doc Public Link</label>
+        <p>Paste the shareable link to your photo documentation.</p>
+        <input id="d6-link" type="url" className="dt-link-input" placeholder="https://drive.google.com/…"
+          value={data.driveLink||''} readOnly={readOnly} style={ro}
+          onChange={e => !readOnly && onChange('driveLink', e.target.value)} />
+      </div>
+      <div className="dt-textarea-wrap">
+        <label htmlFor="d6-notes">Brief Description of Intervention Activity</label>
+        <textarea id="d6-notes" className="dt-textarea" style={{minHeight:100,...ro}}
+          placeholder="Describe your intervention activity and key observations…"
+          value={data.notes||''} readOnly={readOnly}
+          onChange={e => !readOnly && onChange('notes', e.target.value)} />
+      </div>
+    </div>
+  );
+}
+
+/* ── Day 7 ── */
+function Day7({ data, onChange, readOnly }) {
+  const ro = { background: readOnly ? '#f9f9f9' : undefined };
+  return (
+    <div>
+      <div className="dt-info-box" style={{marginBottom:18}}>
+        <h4>Task: Documentation &amp; Presentation</h4>
+        <ul>
+          <li><strong>Case Study Report:</strong> Prepare using the template (will be shared). Upload to Google Docs/Drive.</li>
+          <li><strong>Presentation Video:</strong> PowerPoint + face recording + voiceover.</li>
+          <li>Upload video to <strong>YouTube</strong> and <strong>LinkedIn</strong>.</li>
+          <li>Submit all three links below.</li>
+        </ul>
+      </div>
+      <div className="dt-link-section">
+        <label htmlFor="d7-cs">Case Study Document Public Link</label>
+        <p>Google Docs / Drive link — must be publicly viewable.</p>
+        <input id="d7-cs" type="url" className="dt-link-input" placeholder="https://docs.google.com/…"
+          value={data.caseStudyLink||''} readOnly={readOnly} style={ro}
+          onChange={e => !readOnly && onChange('caseStudyLink', e.target.value)} />
+      </div>
+      <div className="dt-link-section">
+        <label htmlFor="d7-yt">Presentation Video – YouTube Link</label>
+        <p>Upload face + PowerPoint + voiceover video to YouTube (unlisted or public).</p>
+        <input id="d7-yt" type="url" className="dt-link-input" placeholder="https://youtube.com/…"
+          value={data.youtubeLink||''} readOnly={readOnly} style={ro}
+          onChange={e => !readOnly && onChange('youtubeLink', e.target.value)} />
+      </div>
+      <div className="dt-link-section">
+        <label htmlFor="d7-li">Presentation – LinkedIn Post Link</label>
+        <p>Share your video on LinkedIn and paste the post URL.</p>
+        <input id="d7-li" type="url" className="dt-link-input" placeholder="https://linkedin.com/posts/…"
+          value={data.linkedinLink||''} readOnly={readOnly} style={ro}
+          onChange={e => !readOnly && onChange('linkedinLink', e.target.value)} />
+      </div>
+      <div className="dt-warning-box">⚠️ Case study template will be provided soon. Prepare content in advance.</div>
+    </div>
+  );
+}

--- a/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/surveyDataShared.js
+++ b/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/surveyDataShared.js
@@ -1,0 +1,2065 @@
+export const surveyData = {
+  "Poor Personal Hygiene Practices": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you wash hands before eating? (Yes/No)",
+        "Do you wash hands after toilet use? (Yes/No)",
+        "Do you use soap regularly? (Yes/No)",
+        "Do all members bathe daily? (Yes/No)",
+        "Do children follow hygiene practices? (Yes/No)",
+        "Are hygiene products affordable? (Yes/No)",
+        "Do you clean nails regularly? (Yes/No)",
+        "Do you believe hygiene prevents disease? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Do you wash hands before meals? (Yes/No)",
+        "Do you brush teeth twice daily? (Yes/No)",
+        "Do you bathe regularly? (Yes/No)",
+        "Are hygiene habits taught in school? (Yes/No)",
+        "Do you follow them daily? (Yes/No)",
+        "Do you spread awareness? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are hygiene-related illnesses common? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Do people follow hygiene advice? (Yes/No)",
+        "Are children more affected? (Yes/No)",
+        "Is hygiene improving? (Yes/No)",
+        "Are hygiene kits distributed? (Yes/No)"
+      ]
+    }
+  ],
+  "Inadequate Sanitation & Open Defecation": [
+    {
+      stakeholder: "Households",
+      count: 9,
+      questions: [
+        "Do you have a toilet at home? (Yes/No)",
+        "Do all members use it? (Yes/No)",
+        "Is open defecation practiced nearby? (Yes/No)",
+        "Is water available in toilets? (Yes/No)",
+        "Are toilets clean and usable? (Yes/No)",
+        "Are public toilets available? (Yes/No)",
+        "Do children use toilets? (Yes/No)",
+        "Do you face sanitation-related illness? (Yes/No)",
+        "Are sanitation habits improving? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are sanitation-related diseases common? (Yes/No)",
+        "Are awareness campaigns conducted? (Yes/No)",
+        "Are toilets used properly? (Yes/No)",
+        "Are rural areas more affected? (Yes/No)",
+        "Are campaigns effective? (Yes/No)",
+        "Is monitoring regular? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are toilets built under schemes? (Yes/No)",
+        "Are they maintained? (Yes/No)",
+        "Is open defecation monitored? (Yes/No)",
+        "Are awareness drives conducted? (Yes/No)",
+        "Are sanitation workers sufficient? (Yes/No)",
+        "Are funds used properly? (Yes/No)"
+      ]
+    }
+  ],
+  "Unsafe Drinking Water & Hygiene Practices": [
+    {
+      stakeholder: "Households",
+      count: 9,
+      questions: [
+        "Do you drink untreated water? (Yes/No)",
+        "Do you boil/filter water? (Yes/No)",
+        "Is storage hygienic? (Yes/No)",
+        "Do you clean containers regularly? (Yes/No)",
+        "Have you faced illness due to water? (Yes/No)",
+        "Is water source safe? (Yes/No)",
+        "Do you use covered containers? (Yes/No)",
+        "Is supply consistent? (Yes/No)",
+        "Do you trust water quality? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are water-borne diseases common? (Yes/No)",
+        "Is unsafe water a major cause? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are water tests conducted? (Yes/No)",
+        "Are children more affected? (Yes/No)",
+        "Is improvement observed? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Is water tested regularly? (Yes/No)",
+        "Are purification systems available? (Yes/No)",
+        "Are complaints frequent? (Yes/No)",
+        "Are sources protected? (Yes/No)",
+        "Are improvements planned? (Yes/No)",
+        "Are funds allocated? (Yes/No)"
+      ]
+    }
+  ],
+  "Poor Solid Waste Management & Cleanliness": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Is garbage collected regularly? (Yes/No)",
+        "Do you segregate waste? (Yes/No)",
+        "Is waste dumped openly? (Yes/No)",
+        "Are surroundings clean? (Yes/No)",
+        "Do you burn waste? (Yes/No)",
+        "Are dustbins available? (Yes/No)",
+        "Do you face foul smell issues? (Yes/No)",
+        "Do you participate in cleanliness drives? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Sanitation Workers",
+      count: 7,
+      questions: [
+        "Is waste collected daily? (Yes/No)",
+        "Is manpower sufficient? (Yes/No)",
+        "Do people cooperate in waste management? (Yes/No)",
+        "Are tools adequate? (Yes/No)",
+        "Is waste segregation followed? (Yes/No)",
+        "Are dumping points managed properly? (Yes/No)",
+        "Is workload manageable? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 7,
+      questions: [
+        "Is there a waste management system? (Yes/No)",
+        "Are funds available? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are collection vehicles available? (Yes/No)",
+        "Is waste segregation promoted? (Yes/No)",
+        "Are dumping areas designated? (Yes/No)",
+        "Is monitoring done regularly? (Yes/No)"
+      ]
+    }
+  ],
+  "Water-Borne & Vector-Borne Diseases": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Are mosquitoes common? (Yes/No)",
+        "Is stagnant water present? (Yes/No)",
+        "Do you use protection methods? (Yes/No)",
+        "Have dengue/malaria cases occurred? (Yes/No)",
+        "Are surroundings cleaned regularly? (Yes/No)",
+        "Do you report issues? (Yes/No)",
+        "Are fogging activities done? (Yes/No)",
+        "Do you take preventive steps? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are vector diseases common? (Yes/No)",
+        "Are awareness campaigns conducted? (Yes/No)",
+        "Are children affected more? (Yes/No)",
+        "Are prevention measures followed? (Yes/No)",
+        "Is monitoring regular? (Yes/No)",
+        "Are cases increasing? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Is fogging conducted regularly? (Yes/No)",
+        "Are stagnant water points removed? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are drainage systems maintained? (Yes/No)",
+        "Are complaints addressed quickly? (Yes/No)",
+        "Are preventive plans in place? (Yes/No)"
+      ]
+    }
+  ],
+  "Lack of Menstrual Hygiene Awareness": [
+    {
+      stakeholder: "Women/Girls",
+      count: 8,
+      questions: [
+        "Do you use sanitary products? (Yes/No)",
+        "Are products easily available? (Yes/No)",
+        "Do you change them regularly? (Yes/No)",
+        "Do you dispose them safely? (Yes/No)",
+        "Are you aware of hygiene practices? (Yes/No)",
+        "Do you face restrictions? (Yes/No)",
+        "Do you have access to private toilets? (Yes/No)",
+        "Do you feel comfortable discussing it? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are awareness sessions conducted? (Yes/No)",
+        "Are girls informed about hygiene? (Yes/No)",
+        "Are infections common? (Yes/No)",
+        "Are products distributed? (Yes/No)",
+        "Is awareness improving? (Yes/No)",
+        "Are rural women more affected? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Schools",
+      count: 6,
+      questions: [
+        "Are menstrual hygiene sessions conducted? (Yes/No)",
+        "Are sanitary products available? (Yes/No)",
+        "Are toilets adequate? (Yes/No)",
+        "Is privacy maintained? (Yes/No)",
+        "Do girls attend school during periods? (Yes/No)",
+        "Are teachers trained on awareness? (Yes/No)"
+      ]
+    }
+  ],
+  "Malnutrition & Poor Nutrition Practices": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do children receive balanced diet? (Yes/No)",
+        "Are fruits/vegetables consumed daily? (Yes/No)",
+        "Are children underweight? (Yes/No)",
+        "Do you skip meals? (Yes/No)",
+        "Are pregnant women well nourished? (Yes/No)",
+        "Do children fall sick often? (Yes/No)",
+        "Are you aware of nutrition programs? (Yes/No)",
+        "Do you follow healthy diet habits? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Anganwadi Workers",
+      count: 6,
+      questions: [
+        "Are nutrition programs implemented? (Yes/No)",
+        "Are children monitored regularly? (Yes/No)",
+        "Are supplements provided? (Yes/No)",
+        "Are mothers educated? (Yes/No)",
+        "Are records maintained? (Yes/No)",
+        "Are malnutrition cases high? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are malnutrition cases common? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are pregnant women monitored? (Yes/No)",
+        "Are children screened regularly? (Yes/No)",
+        "Are interventions effective? (Yes/No)",
+        "Is improvement visible? (Yes/No)"
+      ]
+    }
+  ],
+  "Limited Access to Healthcare Facilities": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Is a health center nearby? (Yes/No)",
+        "Do you visit doctors regularly? (Yes/No)",
+        "Is transport available? (Yes/No)",
+        "Are medicines affordable? (Yes/No)",
+        "Do you delay treatment? (Yes/No)",
+        "Are doctors available? (Yes/No)",
+        "Are services satisfactory? (Yes/No)",
+        "Do you trust government hospitals? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are facilities sufficient? (Yes/No)",
+        "Are staff adequate? (Yes/No)",
+        "Are patients increasing? (Yes/No)",
+        "Are services accessible? (Yes/No)",
+        "Are outreach programs conducted? (Yes/No)",
+        "Are emergency services available? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are health centers maintained? (Yes/No)",
+        "Are funds allocated? (Yes/No)",
+        "Are services monitored? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are facilities improving? (Yes/No)",
+        "Are complaints addressed? (Yes/No)"
+      ]
+    }
+  ],
+  "Lack of Health Awareness & Preventive Care": [
+    {
+      stakeholder: "Households",
+      count: 7,
+      questions: [
+        "Are you aware of common diseases? (Yes/No)",
+        "Do you attend health camps? (Yes/No)",
+        "Do you follow preventive care? (Yes/No)",
+        "Do you vaccinate children? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Do you seek early treatment? (Yes/No)",
+        "Do you believe prevention is important? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Are health topics taught in school? (Yes/No)",
+        "Do you follow hygiene practices? (Yes/No)",
+        "Do you attend awareness programs? (Yes/No)",
+        "Do you share knowledge with family? (Yes/No)",
+        "Do you understand disease prevention? (Yes/No)",
+        "Are you interested in health initiatives? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are awareness programs conducted regularly? (Yes/No)",
+        "Is participation high? (Yes/No)",
+        "Are rural areas less aware? (Yes/No)",
+        "Are campaigns effective? (Yes/No)",
+        "Is awareness improving? (Yes/No)",
+        "Are materials distributed? (Yes/No)"
+      ]
+    }
+  ],
+  "Poor Environmental Hygiene (Surroundings & Living Conditions)": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Are surroundings clean? (Yes/No)",
+        "Is waste dumped nearby? (Yes/No)",
+        "Are drains clean? (Yes/No)",
+        "Is stagnant water present? (Yes/No)",
+        "Do you clean surroundings regularly? (Yes/No)",
+        "Are animals causing hygiene issues? (Yes/No)",
+        "Are foul smells common? (Yes/No)",
+        "Do you participate in cleaning activities? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Are cleaning activities regular? (Yes/No)",
+        "Is manpower sufficient? (Yes/No)",
+        "Are tools adequate? (Yes/No)",
+        "Do people cooperate? (Yes/No)",
+        "Are problem areas recurring? (Yes/No)",
+        "Is workload manageable? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are cleaning schedules maintained? (Yes/No)",
+        "Are funds sufficient? (Yes/No)",
+        "Are awareness drives conducted? (Yes/No)",
+        "Are complaints resolved? (Yes/No)",
+        "Is monitoring regular? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  // SOLID WASTE MANAGEMENT Problem Statements
+  "Lack of Door-to-Door Waste Collection": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Is waste collected daily from your house? (Yes/No)",
+        "Do workers come regularly? (Yes/No)",
+        "Do you depend on open dumping? (Yes/No)",
+        "Is collection timing fixed? (Yes/No)",
+        "Do you face irregular service? (Yes/No)",
+        "Do you pay for collection? (Yes/No)",
+        "Are you satisfied with service? (Yes/No)",
+        "Do you report missed collection? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Is collection done daily? (Yes/No)",
+        "Is manpower sufficient? (Yes/No)",
+        "Is route coverage complete? (Yes/No)",
+        "Do households cooperate? (Yes/No)",
+        "Are tools adequate? (Yes/No)",
+        "Is workload manageable? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Is system implemented properly? (Yes/No)",
+        "Are complaints addressed? (Yes/No)",
+        "Are funds sufficient? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Are all areas covered? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Absence of Waste Segregation at Source": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you separate wet and dry waste? (Yes/No)",
+        "Are you aware of segregation? (Yes/No)",
+        "Do you have separate bins? (Yes/No)",
+        "Do you follow segregation daily? (Yes/No)",
+        "Do workers insist on segregation? (Yes/No)",
+        "Do you think segregation is useful? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are you willing to follow segregation? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Do households segregate waste? (Yes/No)",
+        "Do you collect segregated waste separately? (Yes/No)",
+        "Is segregation practiced widely? (Yes/No)",
+        "Do you educate households? (Yes/No)",
+        "Is segregation useful in processing? (Yes/No)",
+        "Are tools available? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Is segregation policy implemented? (Yes/No)",
+        "Are awareness campaigns conducted? (Yes/No)",
+        "Are bins distributed? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Is compliance high? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Open Dumping of Waste": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do people dump waste openly? (Yes/No)",
+        "Are dumping spots near your house? (Yes/No)",
+        "Do you dump waste outside? (Yes/No)",
+        "Is there foul smell? (Yes/No)",
+        "Do you face health issues? (Yes/No)",
+        "Are bins unavailable? (Yes/No)",
+        "Do you complain about dumping? (Yes/No)",
+        "Is dumping increasing? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Are dumping spots common? (Yes/No)",
+        "Is cleaning done regularly? (Yes/No)",
+        "Do people cooperate? (Yes/No)",
+        "Are tools sufficient? (Yes/No)",
+        "Are complaints frequent? (Yes/No)",
+        "Is workload high? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are dumping sites identified? (Yes/No)",
+        "Are they cleaned regularly? (Yes/No)",
+        "Are fines imposed? (Yes/No)",
+        "Are bins installed? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Burning of Waste": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do people burn waste locally? (Yes/No)",
+        "Do you burn waste? (Yes/No)",
+        "Does smoke cause problems? (Yes/No)",
+        "Are you aware of its harm? (Yes/No)",
+        "Do you face breathing issues? (Yes/No)",
+        "Is burning frequent? (Yes/No)",
+        "Are alternatives available? (Yes/No)",
+        "Do you report burning? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Is waste burning common? (Yes/No)",
+        "Is it done intentionally? (Yes/No)",
+        "Are alternatives available? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Are complaints received? (Yes/No)",
+        "Is awareness low? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Are rules against burning enforced? (Yes/No)",
+        "Are penalties imposed? (Yes/No)",
+        "Are awareness campaigns conducted? (Yes/No)",
+        "Is monitoring effective? (Yes/No)",
+        "Are alternatives provided? (Yes/No)",
+        "Are improvements visible? (Yes/No)"
+      ]
+    }
+  ],
+  "Poor Waste Collection & Transportation": [
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Is transport available? (Yes/No)",
+        "Are vehicles sufficient? (Yes/No)",
+        "Are routes planned properly? (Yes/No)",
+        "Is collection timely? (Yes/No)",
+        "Is waste transferred safely? (Yes/No)",
+        "Are breakdowns frequent? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are vehicles available? (Yes/No)",
+        "Are funds sufficient? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Are delays common? (Yes/No)",
+        "Are improvements planned? (Yes/No)",
+        "Is system efficient? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Households",
+      count: 6,
+      questions: [
+        "Is waste collected regularly? (Yes/No)",
+        "Do delays occur? (Yes/No)",
+        "Is waste left uncollected? (Yes/No)",
+        "Do you face inconvenience? (Yes/No)",
+        "Do you report issues? (Yes/No)",
+        "Are services improving? (Yes/No)"
+      ]
+    }
+  ],
+  "Lack of Waste Processing (Recycling/Composting)": [
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are composting units available? (Yes/No)",
+        "Are recycling systems present? (Yes/No)",
+        "Is waste processed locally? (Yes/No)",
+        "Are funds allocated? (Yes/No)",
+        "Are facilities functional? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Workers",
+      count: 6,
+      questions: [
+        "Is waste segregated for processing? (Yes/No)",
+        "Are composting practices followed? (Yes/No)",
+        "Is recycling done regularly? (Yes/No)",
+        "Are facilities sufficient? (Yes/No)",
+        "Are tools adequate? (Yes/No)",
+        "Is workload manageable? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Households",
+      count: 6,
+      questions: [
+        "Do you compost waste? (Yes/No)",
+        "Are you aware of recycling? (Yes/No)",
+        "Do you segregate for processing? (Yes/No)",
+        "Do you support composting? (Yes/No)",
+        "Are facilities available nearby? (Yes/No)",
+        "Are you willing to adopt methods? (Yes/No)"
+      ]
+    }
+  ],
+  "Plastic Waste Mismanagement": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you use plastic bags regularly? (Yes/No)",
+        "Do you reuse plastic? (Yes/No)",
+        "Do you dispose plastic properly? (Yes/No)",
+        "Are alternatives available? (Yes/No)",
+        "Do you know plastic harms environment? (Yes/No)",
+        "Is plastic waste increasing? (Yes/No)",
+        "Do you reduce usage? (Yes/No)",
+        "Do you support plastic ban? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Shopkeepers",
+      count: 6,
+      questions: [
+        "Do you provide plastic bags? (Yes/No)",
+        "Are alternatives available? (Yes/No)",
+        "Do customers demand plastic? (Yes/No)",
+        "Is plastic ban followed? (Yes/No)",
+        "Are fines imposed? (Yes/No)",
+        "Are reusable options promoted? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Is plastic ban implemented? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Are penalties imposed? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Is plastic waste increasing? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Lack of Awareness on Waste Management": [
+    {
+      stakeholder: "Households",
+      count: 7,
+      questions: [
+        "Are you aware of waste management? (Yes/No)",
+        "Do you follow proper disposal? (Yes/No)",
+        "Do you segregate waste? (Yes/No)",
+        "Do you attend awareness programs? (Yes/No)",
+        "Do you educate others? (Yes/No)",
+        "Do you think waste is a serious issue? (Yes/No)",
+        "Are awareness campaigns effective? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Are waste topics taught in school? (Yes/No)",
+        "Do you practice cleanliness? (Yes/No)",
+        "Do you participate in campaigns? (Yes/No)",
+        "Do you spread awareness? (Yes/No)",
+        "Are school programs conducted? (Yes/No)",
+        "Are you interested in solving issues? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "NGOs",
+      count: 6,
+      questions: [
+        "Are awareness programs conducted? (Yes/No)",
+        "Is participation high? (Yes/No)",
+        "Are campaigns effective? (Yes/No)",
+        "Are materials distributed? (Yes/No)",
+        "Is awareness improving? (Yes/No)",
+        "Are challenges present? (Yes/No)"
+      ]
+    }
+  ],
+  "Poor Governance & Monitoring": [
+    {
+      stakeholder: "Panchayat",
+      count: 8,
+      questions: [
+        "Is there a waste management plan? (Yes/No)",
+        "Are rules enforced? (Yes/No)",
+        "Are funds used properly? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Are workers supervised? (Yes/No)",
+        "Are meetings conducted? (Yes/No)",
+        "Is data recorded? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Are policies implemented? (Yes/No)",
+        "Is monitoring effective? (Yes/No)",
+        "Are violations penalized? (Yes/No)",
+        "Are systems digitized? (Yes/No)",
+        "Are programs active? (Yes/No)",
+        "Are improvements visible? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Community Leaders",
+      count: 6,
+      questions: [
+        "Are people aware of rules? (Yes/No)",
+        "Is participation high? (Yes/No)",
+        "Are issues reported? (Yes/No)",
+        "Are solutions discussed? (Yes/No)",
+        "Are conflicts present? (Yes/No)",
+        "Is transparency maintained? (Yes/No)"
+      ]
+    }
+  ],
+  "Health & Environmental Impact": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you face health issues due to waste? (Yes/No)",
+        "Are mosquitoes increasing? (Yes/No)",
+        "Is foul smell common? (Yes/No)",
+        "Is water contaminated? (Yes/No)",
+        "Are surroundings unhealthy? (Yes/No)",
+        "Do children fall sick frequently? (Yes/No)",
+        "Do you feel environment is degrading? (Yes/No)",
+        "Are conditions worsening? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Health Workers",
+      count: 6,
+      questions: [
+        "Are waste-related diseases common? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are children affected more? (Yes/No)",
+        "Is monitoring done? (Yes/No)",
+        "Are cases increasing? (Yes/No)",
+        "Are interventions effective? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Panchayat",
+      count: 6,
+      questions: [
+        "Are health risks identified? (Yes/No)",
+        "Are actions taken? (Yes/No)",
+        "Are waste areas monitored? (Yes/No)",
+        "Are clean-up drives conducted? (Yes/No)",
+        "Are improvements visible? (Yes/No)",
+        "Are future plans available? (Yes/No)"
+      ]
+    }
+  ],
+  // DIGITAL LITERACY & ICT Problem Statements
+  "Lack of Basic Digital Literacy Skills": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you know how to use a smartphone? (Yes/No)",
+        "Can you operate basic apps? (Yes/No)",
+        "Can you search information online? (Yes/No)",
+        "Do you use the internet daily? (Yes/No)",
+        "Do you need help using digital devices? (Yes/No)",
+        "Have you received any digital training? (Yes/No)",
+        "Do you feel confident using technology? (Yes/No)",
+        "Do you use digital services independently? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Do you use digital devices daily? (Yes/No)",
+        "Are digital skills taught in school? (Yes/No)",
+        "Can you use apps independently? (Yes/No)",
+        "Do you help others use technology? (Yes/No)",
+        "Do you use the internet for learning? (Yes/No)",
+        "Are you confident in digital usage? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Trainers",
+      count: 6,
+      questions: [
+        "Are training programs conducted? (Yes/No)",
+        "Is participation high? (Yes/No)",
+        "Are people interested in learning? (Yes/No)",
+        "Is digital awareness low? (Yes/No)",
+        "Are resources sufficient? (Yes/No)",
+        "Are outcomes improving? (Yes/No)"
+      ]
+    }
+  ],
+  "Low Awareness of Online Government Services": [
+    {
+      stakeholder: "Citizens",
+      count: 8,
+      questions: [
+        "Are you aware of online government services? (Yes/No)",
+        "Do you use online services? (Yes/No)",
+        "Do you depend on others to access services? (Yes/No)",
+        "Do you face difficulty using portals? (Yes/No)",
+        "Do you visit offices instead of using online services? (Yes/No)",
+        "Are services easy to understand? (Yes/No)",
+        "Do you know about available schemes? (Yes/No)",
+        "Do you trust digital services? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Are digital services promoted? (Yes/No)",
+        "Is awareness low among citizens? (Yes/No)",
+        "Are users trained? (Yes/No)",
+        "Are portals user-friendly? (Yes/No)",
+        "Are complaints frequent? (Yes/No)",
+        "Are improvements ongoing? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "CSC Operators",
+      count: 6,
+      questions: [
+        "Do citizens depend on your services? (Yes/No)",
+        "Are services used frequently? (Yes/No)",
+        "Are errors common? (Yes/No)",
+        "Is demand increasing? (Yes/No)",
+        "Are charges affordable? (Yes/No)",
+        "Do users face difficulties? (Yes/No)"
+      ]
+    }
+  ],
+  "Inability to Use Email & Formal Digital Communication": [
+    {
+      stakeholder: "Students",
+      count: 7,
+      questions: [
+        "Do you have an email ID? (Yes/No)",
+        "Can you send emails? (Yes/No)",
+        "Can you attach files? (Yes/No)",
+        "Are email writing skills taught? (Yes/No)",
+        "Do you know formal email format? (Yes/No)",
+        "Do you use email regularly? (Yes/No)",
+        "Are you confident writing emails? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Job Seekers",
+      count: 7,
+      questions: [
+        "Do you use email for job applications? (Yes/No)",
+        "Can you write professional emails? (Yes/No)",
+        "Do you send resumes online? (Yes/No)",
+        "Do you face difficulty writing emails? (Yes/No)",
+        "Do you receive responses? (Yes/No)",
+        "Are you trained in communication? (Yes/No)",
+        "Does this affect job opportunities? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Trainers",
+      count: 6,
+      questions: [
+        "Are email skills taught? (Yes/No)",
+        "Is awareness low? (Yes/No)",
+        "Are students interested? (Yes/No)",
+        "Are practice sessions conducted? (Yes/No)",
+        "Are outcomes improving? (Yes/No)",
+        "Are materials available? (Yes/No)"
+      ]
+    }
+  ],
+  "Limited Access to Digital Devices (Smartphones/Computers)": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you own a smartphone? (Yes/No)",
+        "Do you have a computer/laptop? (Yes/No)",
+        "Are devices shared? (Yes/No)",
+        "Is device affordability an issue? (Yes/No)",
+        "Do children have access? (Yes/No)",
+        "Do you use devices daily? (Yes/No)",
+        "Do you face difficulty accessing devices? (Yes/No)",
+        "Is lack of devices a problem? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Do you have a personal device? (Yes/No)",
+        "Do you use it for studies? (Yes/No)",
+        "Do you face access issues? (Yes/No)",
+        "Do you depend on others? (Yes/No)",
+        "Is device sufficient for learning? (Yes/No)",
+        "Do you use shared/public devices? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Vendors",
+      count: 6,
+      questions: [
+        "Is demand for devices increasing? (Yes/No)",
+        "Are devices affordable? (Yes/No)",
+        "Do people prefer smartphones? (Yes/No)",
+        "Are repairs frequent? (Yes/No)",
+        "Is awareness about devices low? (Yes/No)",
+        "Are customers informed about features? (Yes/No)"
+      ]
+    }
+  ],
+  "Poor Internet Connectivity": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you have internet access? (Yes/No)",
+        "Is the connection stable? (Yes/No)",
+        "Is speed sufficient? (Yes/No)",
+        "Do outages occur frequently? (Yes/No)",
+        "Is internet affordable? (Yes/No)",
+        "Do you depend on mobile data? (Yes/No)",
+        "Does internet affect daily tasks? (Yes/No)",
+        "Do you face connectivity issues regularly? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Does poor internet affect studies? (Yes/No)",
+        "Do you attend online classes? (Yes/No)",
+        "Is speed sufficient? (Yes/No)",
+        "Do you face interruptions? (Yes/No)",
+        "Do you use Wi-Fi? (Yes/No)",
+        "Do you face access issues? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Providers",
+      count: 6,
+      questions: [
+        "Is coverage sufficient? (Yes/No)",
+        "Are complaints frequent? (Yes/No)",
+        "Is infrastructure adequate? (Yes/No)",
+        "Are upgrades ongoing? (Yes/No)",
+        "Is demand increasing? (Yes/No)",
+        "Are issues resolved quickly? (Yes/No)"
+      ]
+    }
+  ],
+  "Lack of Awareness on Cyber Safety & Security": [
+    {
+      stakeholder: "Users",
+      count: 7,
+      questions: [
+        "Are you aware of online scams? (Yes/No)",
+        "Do you use strong passwords? (Yes/No)",
+        "Have you faced fraud? (Yes/No)",
+        "Do you share OTP/passwords? (Yes/No)",
+        "Do you verify unknown links? (Yes/No)",
+        "Do you use secure apps? (Yes/No)",
+        "Are you aware of cyber safety rules? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Are cyber safety topics taught? (Yes/No)",
+        "Do you know about phishing? (Yes/No)",
+        "Do you follow safe practices? (Yes/No)",
+        "Do you share personal info online? (Yes/No)",
+        "Are awareness sessions conducted? (Yes/No)",
+        "Are you confident about online safety? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Are awareness programs conducted? (Yes/No)",
+        "Are complaints increasing? (Yes/No)",
+        "Are systems secure? (Yes/No)",
+        "Is monitoring effective? (Yes/No)",
+        "Are people reporting fraud? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Low Adoption of Digital Payments": [
+    {
+      stakeholder: "Households",
+      count: 8,
+      questions: [
+        "Do you use digital payments? (Yes/No)",
+        "Do you use UPI regularly? (Yes/No)",
+        "Do you trust digital payments? (Yes/No)",
+        "Do you face transaction issues? (Yes/No)",
+        "Do you prefer cash? (Yes/No)",
+        "Are you aware of payment apps? (Yes/No)",
+        "Do you need help using them? (Yes/No)",
+        "Do you feel they are safe? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Shopkeepers",
+      count: 6,
+      questions: [
+        "Do you accept digital payments? (Yes/No)",
+        "Is usage increasing? (Yes/No)",
+        "Do customers prefer digital? (Yes/No)",
+        "Are transactions smooth? (Yes/No)",
+        "Do you face issues? (Yes/No)",
+        "Are QR systems available? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Banks",
+      count: 6,
+      questions: [
+        "Are customers adopting digital payments? (Yes/No)",
+        "Are awareness programs conducted? (Yes/No)",
+        "Are fraud cases increasing? (Yes/No)",
+        "Are systems reliable? (Yes/No)",
+        "Is adoption growing? (Yes/No)",
+        "Are improvements planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Limited Use of ICT in Education": [
+    {
+      stakeholder: "Students",
+      count: 6,
+      questions: [
+        "Do you use ICT tools for learning? (Yes/No)",
+        "Are online classes available? (Yes/No)",
+        "Do you access digital content? (Yes/No)",
+        "Do you face difficulty using tools? (Yes/No)",
+        "Are devices available? (Yes/No)",
+        "Is ICT helpful? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Teachers",
+      count: 6,
+      questions: [
+        "Do you use digital tools? (Yes/No)",
+        "Are you trained in ICT? (Yes/No)",
+        "Are facilities available? (Yes/No)",
+        "Do students engage well? (Yes/No)",
+        "Are challenges present? (Yes/No)",
+        "Are improvements needed? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Schools",
+      count: 6,
+      questions: [
+        "Are ICT labs available? (Yes/No)",
+        "Are devices sufficient? (Yes/No)",
+        "Is internet available? (Yes/No)",
+        "Are teachers trained? (Yes/No)",
+        "Are programs implemented? (Yes/No)",
+        "Are upgrades planned? (Yes/No)"
+      ]
+    }
+  ],
+  "Difficulty in Online Form Filling & Digital Documentation": [
+    {
+      stakeholder: "Citizens",
+      count: 8,
+      questions: [
+        "Do you fill forms online? (Yes/No)",
+        "Do you need help? (Yes/No)",
+        "Do you face errors? (Yes/No)",
+        "Are forms easy to understand? (Yes/No)",
+        "Do you visit centers for help? (Yes/No)",
+        "Are documents ready? (Yes/No)",
+        "Do you know upload process? (Yes/No)",
+        "Are services time-consuming? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "CSC",
+      count: 6,
+      questions: [
+        "Are people dependent on you? (Yes/No)",
+        "Are forms complex? (Yes/No)",
+        "Are errors common? (Yes/No)",
+        "Is demand high? (Yes/No)",
+        "Are services affordable? (Yes/No)",
+        "Are issues frequent? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Officials",
+      count: 6,
+      questions: [
+        "Are portals user-friendly? (Yes/No)",
+        "Are complaints frequent? (Yes/No)",
+        "Are improvements ongoing? (Yes/No)",
+        "Are services digitized? (Yes/No)",
+        "Is awareness low? (Yes/No)",
+        "Are systems efficient? (Yes/No)"
+      ]
+    }
+  ],
+  "Fear and Low Confidence in Using Technology": [
+    {
+      stakeholder: "Households",
+      count: 7,
+      questions: [
+        "Do you feel scared using technology? (Yes/No)",
+        "Do you depend on others? (Yes/No)",
+        "Do you avoid digital services? (Yes/No)",
+        "Do you feel it is complicated? (Yes/No)",
+        "Do you want to learn? (Yes/No)",
+        "Do you lack confidence? (Yes/No)",
+        "Are training opportunities available? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Elderly",
+      count: 6,
+      questions: [
+        "Do you use smartphones? (Yes/No)",
+        "Do you need help? (Yes/No)",
+        "Do you avoid digital tools? (Yes/No)",
+        "Are you interested in learning? (Yes/No)",
+        "Do you feel insecure? (Yes/No)",
+        "Do you trust digital systems? (Yes/No)"
+      ]
+    },
+    {
+      stakeholder: "Trainers",
+      count: 6,
+      questions: [
+        "Is fear common? (Yes/No)",
+        "Are training programs effective? (Yes/No)",
+        "Are people willing to learn? (Yes/No)",
+        "Are challenges high? (Yes/No)",
+        "Is improvement visible? (Yes/No)",
+        "Are resources sufficient? (Yes/No)"
+      ]
+    }
+  ],
+  // WOMEN EMPOWERMENT & GENDER EQUALITY
+  "Low Awareness of Women's Rights & Legal Protection": [
+    { stakeholder: "Women", count: 8, questions: ["Are you aware of your legal rights? (Yes/No)","Do you know about women protection laws? (Yes/No)","Do you know where to report issues? (Yes/No)","Do you feel your rights are respected? (Yes/No)","Have you attended awareness programs? (Yes/No)","Do you feel confident to raise issues? (Yes/No)","Are support systems available? (Yes/No)","Do you believe awareness is low? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are women aware of schemes? (Yes/No)","Are complaints increasing? (Yes/No)","Are systems accessible? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are awareness drives conducted? (Yes/No)","Is awareness low? (Yes/No)","Are women participating? (Yes/No)","Are campaigns effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Limited Access to Education for Girls/Women": [
+    { stakeholder: "Girls/Students", count: 7, questions: ["Are you attending school regularly? (Yes/No)","Do you face barriers to education? (Yes/No)","Are facilities sufficient? (Yes/No)","Do you feel encouraged to study? (Yes/No)","Do you have access to learning materials? (Yes/No)","Do you plan to continue education? (Yes/No)","Are dropouts common? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you support girls' education? (Yes/No)","Are financial issues a barrier? (Yes/No)","Do you prefer boys' education? (Yes/No)","Are schools accessible? (Yes/No)","Do you encourage higher education? (Yes/No)","Are girls dropping out early? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are girls attending regularly? (Yes/No)","Are dropouts common? (Yes/No)","Are facilities adequate? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are parents supportive? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Financial Dependency & Lack of Economic Opportunities": [
+    { stakeholder: "Women", count: 8, questions: ["Do you earn independently? (Yes/No)","Do you have your own bank account? (Yes/No)","Do you participate in financial decisions? (Yes/No)","Are job opportunities available? (Yes/No)","Do you have skills for employment? (Yes/No)","Are you part of SHGs? (Yes/No)","Do you feel financially dependent? (Yes/No)","Do you want to earn? (Yes/No)"] },
+    { stakeholder: "SHGs", count: 6, questions: ["Are women participating actively? (Yes/No)","Are loans accessible? (Yes/No)","Are income activities successful? (Yes/No)","Are trainings provided? (Yes/No)","Is financial literacy low? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are women benefiting? (Yes/No)","Are awareness programs conducted? (Yes/No)","Is participation increasing? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)"] }
+  ],
+  "Low Participation of Women in Decision-Making": [
+    { stakeholder: "Women", count: 7, questions: ["Do you participate in family decisions? (Yes/No)","Are your opinions valued? (Yes/No)","Do you take financial decisions? (Yes/No)","Do you attend community meetings? (Yes/No)","Do you feel empowered? (Yes/No)","Do you face restrictions? (Yes/No)","Do you want more involvement? (Yes/No)"] },
+    { stakeholder: "Family Members", count: 6, questions: ["Are women included in decisions? (Yes/No)","Are their opinions respected? (Yes/No)","Do women handle finances? (Yes/No)","Are restrictions present? (Yes/No)","Is participation increasing? (Yes/No)","Are changes needed? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are women participating in governance? (Yes/No)","Are meetings inclusive? (Yes/No)","Are women encouraged? (Yes/No)","Are barriers present? (Yes/No)","Is representation adequate? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Gender Discrimination in Households & Society": [
+    { stakeholder: "Women", count: 8, questions: ["Do you face discrimination? (Yes/No)","Are opportunities unequal? (Yes/No)","Are boys preferred over girls? (Yes/No)","Do you face restrictions? (Yes/No)","Are wages unequal? (Yes/No)","Do you feel respected? (Yes/No)","Is discrimination common? (Yes/No)","Are changes happening? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Do you believe in gender equality? (Yes/No)","Do you see discrimination? (Yes/No)","Are girls treated equally? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you support equality? (Yes/No)","Are attitudes changing? (Yes/No)"] },
+    { stakeholder: "Community Leaders", count: 6, questions: ["Are equality policies implemented? (Yes/No)","Is discrimination reported? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are complaints addressed? (Yes/No)","Are actions taken? (Yes/No)"] }
+  ],
+  "Lack of Awareness on Health & Menstrual Hygiene": [
+    { stakeholder: "Women", count: 8, questions: ["Are you aware of health practices? (Yes/No)","Do you access healthcare services? (Yes/No)","Are menstrual hygiene products available? (Yes/No)","Do you follow hygiene practices? (Yes/No)","Are you comfortable discussing health? (Yes/No)","Do you attend health camps? (Yes/No)","Are services accessible? (Yes/No)","Do you face health issues? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Are women attending programs? (Yes/No)","Are services accessible? (Yes/No)","Are issues common? (Yes/No)","Are improvements visible? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are hygiene sessions conducted? (Yes/No)","Are facilities adequate? (Yes/No)","Are girls attending regularly? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are teachers trained? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Safety & Security Issues (Harassment, Violence)": [
+    { stakeholder: "Women", count: 8, questions: ["Do you feel safe in your area? (Yes/No)","Do you face harassment? (Yes/No)","Are streets well-lit? (Yes/No)","Do you travel safely? (Yes/No)","Do you report issues? (Yes/No)","Are support systems available? (Yes/No)","Are incidents increasing? (Yes/No)","Do you feel protected? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are safety measures implemented? (Yes/No)","Are complaints addressed? (Yes/No)","Are patrols conducted? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are cases increasing? (Yes/No)","Are improvements planned? (Yes/No)"] },
+    { stakeholder: "Community", count: 6, questions: ["Do people support women safety? (Yes/No)","Are incidents reported? (Yes/No)","Is awareness high? (Yes/No)","Are safety measures followed? (Yes/No)","Are problems discussed openly? (Yes/No)","Are changes happening? (Yes/No)"] }
+  ],
+  "Limited Digital Literacy & ICT Access for Women": [
+    { stakeholder: "Women", count: 8, questions: ["Do you use smartphones? (Yes/No)","Can you use apps independently? (Yes/No)","Do you access online services? (Yes/No)","Do you depend on others? (Yes/No)","Have you received training? (Yes/No)","Do you feel confident? (Yes/No)","Are digital skills useful? (Yes/No)","Do you want to learn more? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Do women use digital tools? (Yes/No)","Do you help them? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are women interested? (Yes/No)","Are skills improving? (Yes/No)","Are barriers present? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes improving? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Low Participation in Skill Development & Employment": [
+    { stakeholder: "Women", count: 8, questions: ["Have you received skill training? (Yes/No)","Are jobs available? (Yes/No)","Do you want employment? (Yes/No)","Are training programs accessible? (Yes/No)","Are skills relevant? (Yes/No)","Do you face barriers? (Yes/No)","Are opportunities equal? (Yes/No)","Are you currently employed? (Yes/No)"] },
+    { stakeholder: "Training Centers", count: 6, questions: ["Are programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are placements provided? (Yes/No)","Are resources sufficient? (Yes/No)","Are outcomes effective? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Do you hire women? (Yes/No)","Are opportunities equal? (Yes/No)","Are skills sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are policies supportive? (Yes/No)","Is participation increasing? (Yes/No)"] }
+  ],
+  "Social Barriers, Stereotypes & Early Marriage": [
+    { stakeholder: "Women", count: 7, questions: ["Do social norms restrict you? (Yes/No)","Are early marriages common? (Yes/No)","Do you have freedom of choice? (Yes/No)","Do you face pressure? (Yes/No)","Are opportunities limited? (Yes/No)","Do you want change? (Yes/No)","Are conditions improving? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you support early marriage? (Yes/No)","Are social pressures present? (Yes/No)","Do you support girls' education? (Yes/No)","Are traditions influencing decisions? (Yes/No)","Are attitudes changing? (Yes/No)","Are awareness programs conducted? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are awareness campaigns conducted? (Yes/No)","Are cases reported? (Yes/No)","Are policies enforced? (Yes/No)","Are improvements visible? (Yes/No)","Are community discussions held? (Yes/No)","Are actions taken? (Yes/No)"] }
+  ],
+  // NUTRITION & FOOD SECURITY
+  "Lack of Awareness about Balanced Diet": [
+    { stakeholder: "Households", count: 8, questions: ["Do you know what a balanced diet is? (Yes/No)","Do you include vegetables daily? (Yes/No)","Do you include protein foods regularly? (Yes/No)","Do you understand nutrition importance? (Yes/No)","Do you attend awareness programs? (Yes/No)","Do you provide balanced food to children? (Yes/No)","Do you depend on cheap food options? (Yes/No)","Do you feel awareness is low? (Yes/No)"] },
+    { stakeholder: "Women", count: 8, questions: ["Do you know about proper nutrition? (Yes/No)","Do you follow a balanced diet? (Yes/No)","Do you prioritize your diet? (Yes/No)","Do you face food limitations? (Yes/No)","Are you aware of supplements? (Yes/No)","Do you attend health sessions? (Yes/No)","Do you receive guidance? (Yes/No)","Do you feel awareness is lacking? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are mothers informed? (Yes/No)","Is malnutrition common? (Yes/No)","Are materials distributed? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Child Malnutrition": [
+    { stakeholder: "Mothers", count: 8, questions: ["Are your children underweight? (Yes/No)","Do children eat nutritious food? (Yes/No)","Do children fall sick often? (Yes/No)","Do you provide 3 meals daily? (Yes/No)","Are growth issues observed? (Yes/No)","Do you attend Anganwadi services? (Yes/No)","Are supplements given? (Yes/No)","Are you aware of nutrition needs? (Yes/No)"] },
+    { stakeholder: "Anganwadi Workers", count: 6, questions: ["Are children monitored regularly? (Yes/No)","Are malnutrition cases high? (Yes/No)","Are supplements provided? (Yes/No)","Are mothers educated? (Yes/No)","Are records maintained? (Yes/No)","Are improvements seen? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are malnutrition cases common? (Yes/No)","Are screenings conducted? (Yes/No)","Are interventions effective? (Yes/No)","Are mothers cooperative? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Poor Maternal Nutrition": [
+    { stakeholder: "Women", count: 8, questions: ["Do you get proper nutrition during pregnancy? (Yes/No)","Do you take supplements regularly? (Yes/No)","Do you attend check-ups? (Yes/No)","Do you follow doctor advice? (Yes/No)","Do you face food shortage? (Yes/No)","Are you aware of nutrition? (Yes/No)","Do you feel weak often? (Yes/No)","Are services accessible? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are pregnant women monitored? (Yes/No)","Are supplements provided? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are services accessible? (Yes/No)","Are complications common? (Yes/No)","Are improvements visible? (Yes/No)"] },
+    { stakeholder: "Anganwadi Workers", count: 6, questions: ["Are pregnant women registered? (Yes/No)","Are services provided? (Yes/No)","Are follow-ups done? (Yes/No)","Are records maintained? (Yes/No)","Are awareness sessions conducted? (Yes/No)","Are outcomes improving? (Yes/No)"] }
+  ],
+  "Limited Access to Nutritious Food": [
+    { stakeholder: "Households", count: 8, questions: ["Do you have access to fresh food? (Yes/No)","Are nutritious foods affordable? (Yes/No)","Do you face food shortages? (Yes/No)","Do you consume protein foods? (Yes/No)","Are markets accessible? (Yes/No)","Do you depend on low-cost food? (Yes/No)","Is food quality good? (Yes/No)","Are prices a concern? (Yes/No)"] },
+    { stakeholder: "Vendors", count: 6, questions: ["Are nutritious foods available? (Yes/No)","Are prices affordable? (Yes/No)","Is demand high? (Yes/No)","Are supplies consistent? (Yes/No)","Are shortages common? (Yes/No)","Are healthy options sold? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are supplies regular? (Yes/No)","Are beneficiaries satisfied? (Yes/No)","Are complaints frequent? (Yes/No)","Is monitoring active? (Yes/No)","Are improvements planned? (Yes/No)"] }
+  ],
+  "High Dependence on Junk Food": [
+    { stakeholder: "Youth", count: 7, questions: ["Do you consume junk food regularly? (Yes/No)","Do you prefer fast food? (Yes/No)","Are healthy options available? (Yes/No)","Do you know risks? (Yes/No)","Is junk food easily available? (Yes/No)","Do you spend daily on snacks? (Yes/No)","Are habits changing? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do children demand junk food? (Yes/No)","Do you allow it frequently? (Yes/No)","Are healthy alternatives provided? (Yes/No)","Are you aware of risks? (Yes/No)","Do you monitor diet? (Yes/No)","Are changes needed? (Yes/No)"] },
+    { stakeholder: "Shopkeepers", count: 6, questions: ["Is junk food demand high? (Yes/No)","Are children main customers? (Yes/No)","Are sales increasing? (Yes/No)","Are healthy options available? (Yes/No)","Are regulations followed? (Yes/No)","Are alternatives promoted? (Yes/No)"] }
+  ],
+  "Ineffective Implementation of Nutrition Schemes": [
+    { stakeholder: "Beneficiaries", count: 8, questions: ["Are you aware of schemes? (Yes/No)","Do you receive benefits regularly? (Yes/No)","Are services satisfactory? (Yes/No)","Are supplies sufficient? (Yes/No)","Do you face delays? (Yes/No)","Are services accessible? (Yes/No)","Are you satisfied? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Anganwadi Workers", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are supplies regular? (Yes/No)","Are records maintained? (Yes/No)","Are beneficiaries attending? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes monitored? (Yes/No)","Are complaints addressed? (Yes/No)","Are funds sufficient? (Yes/No)","Are gaps identified? (Yes/No)","Are improvements planned? (Yes/No)","Are outcomes improving? (Yes/No)"] }
+  ],
+  "Household Food Insecurity": [
+    { stakeholder: "Households", count: 8, questions: ["Do you face food shortages? (Yes/No)","Do you skip meals? (Yes/No)","Is income insufficient? (Yes/No)","Do you depend on ration? (Yes/No)","Do you borrow food/money? (Yes/No)","Are children affected? (Yes/No)","Is food quality low? (Yes/No)","Are conditions worsening? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are poor families common? (Yes/No)","Are food shortages frequent? (Yes/No)","Are schemes effective? (Yes/No)","Are people dependent? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are food programs implemented? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are complaints frequent? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are conditions improving? (Yes/No)"] }
+  ],
+  "Lack of Nutrition Education in Schools": [
+    { stakeholder: "Students", count: 6, questions: ["Are nutrition topics taught? (Yes/No)","Do you follow healthy eating? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you prefer junk food? (Yes/No)","Are facilities adequate? (Yes/No)","Are meals nutritious? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are nutrition topics covered? (Yes/No)","Are awareness sessions conducted? (Yes/No)","Are students interested? (Yes/No)","Are materials available? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are midday meals provided? (Yes/No)","Are meals nutritious? (Yes/No)","Are facilities adequate? (Yes/No)","Are programs implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are standards maintained? (Yes/No)"] }
+  ],
+  "Poor Infant & Child Feeding Practices": [
+    { stakeholder: "Mothers", count: 8, questions: ["Do you breastfeed regularly? (Yes/No)","Do you start feeding on time? (Yes/No)","Do you provide nutritious food? (Yes/No)","Are feeding practices proper? (Yes/No)","Do you follow advice? (Yes/No)","Do you face challenges? (Yes/No)","Are you aware of practices? (Yes/No)","Are services accessible? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are mothers educated? (Yes/No)","Are practices followed? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are issues common? (Yes/No)","Are improvements visible? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Anganwadi Workers", count: 6, questions: ["Are mothers trained? (Yes/No)","Are sessions conducted? (Yes/No)","Are records maintained? (Yes/No)","Are outcomes improving? (Yes/No)","Are services accessible? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Micronutrient Deficiency": [
+    { stakeholder: "Households", count: 8, questions: ["Do you consume iron-rich food? (Yes/No)","Do you face anemia issues? (Yes/No)","Are supplements taken? (Yes/No)","Do children show weakness? (Yes/No)","Are you aware of deficiencies? (Yes/No)","Do you consume fruits regularly? (Yes/No)","Are diet habits poor? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are deficiency cases common? (Yes/No)","Are supplements provided? (Yes/No)","Are screenings done? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are supplements provided? (Yes/No)","Are screenings conducted? (Yes/No)","Are awareness sessions conducted? (Yes/No)","Are students affected? (Yes/No)","Are programs effective? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  // WATER & SANITATION
+  "Unsafe Drinking Water Quality": [
+    { stakeholder: "Households", count: 8, questions: ["Is your drinking water clean? (Yes/No)","Do you face water contamination issues? (Yes/No)","Do you treat water before drinking? (Yes/No)","Does water have bad smell/taste? (Yes/No)","Do family members fall sick often? (Yes/No)","Do you trust the water source? (Yes/No)","Are filtration methods used? (Yes/No)","Do you think water quality is poor? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are water-borne diseases common? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are contamination cases reported? (Yes/No)","Are households informed about safety? (Yes/No)","Are improvements visible? (Yes/No)","Are tests conducted regularly? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is water quality monitored? (Yes/No)","Are tests conducted regularly? (Yes/No)","Are complaints addressed? (Yes/No)","Are purification systems available? (Yes/No)","Are improvements planned? (Yes/No)","Are standards maintained? (Yes/No)"] }
+  ],
+  "Irregular Water Supply": [
+    { stakeholder: "Households", count: 8, questions: ["Do you receive water regularly? (Yes/No)","Is supply sufficient? (Yes/No)","Do you face shortages? (Yes/No)","Do you depend on alternative sources? (Yes/No)","Is timing fixed? (Yes/No)","Are interruptions frequent? (Yes/No)","Do you store water due to shortage? (Yes/No)","Are you satisfied with supply? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Is supply regular? (Yes/No)","Are pipelines functioning properly? (Yes/No)","Are breakdowns frequent? (Yes/No)","Is maintenance adequate? (Yes/No)","Are complaints common? (Yes/No)","Are issues resolved quickly? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is water supply planned properly? (Yes/No)","Are all areas covered? (Yes/No)","Are shortages reported? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements ongoing? (Yes/No)","Is monitoring effective? (Yes/No)"] }
+  ],
+  "Lack of Household Toilet Facilities": [
+    { stakeholder: "Households", count: 8, questions: ["Do you have a toilet at home? (Yes/No)","Do all family members use it? (Yes/No)","Is toilet functional? (Yes/No)","Do you face water issues for toilet use? (Yes/No)","Is toilet maintained properly? (Yes/No)","Do you feel toilets are necessary? (Yes/No)","Do you plan to build one? (Yes/No)","Do you face space/cost issues? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are toilet schemes implemented? (Yes/No)","Are funds provided? (Yes/No)","Are households covered? (Yes/No)","Are inspections done? (Yes/No)","Are complaints addressed? (Yes/No)","Are improvements planned? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are toilets constructed properly? (Yes/No)","Are materials sufficient? (Yes/No)","Are maintenance issues common? (Yes/No)","Are households cooperative? (Yes/No)","Are repairs frequent? (Yes/No)","Are services effective? (Yes/No)"] }
+  ],
+  "Open Defecation Practices": [
+    { stakeholder: "Households", count: 8, questions: ["Do people practice open defecation? (Yes/No)","Do you or family members go outside? (Yes/No)","Are toilets unavailable? (Yes/No)","Are toilets not used regularly? (Yes/No)","Is it considered normal practice? (Yes/No)","Do you feel it is unsafe? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are practices reducing? (Yes/No)"] },
+    { stakeholder: "Community Leaders", count: 6, questions: ["Is open defecation common? (Yes/No)","Are awareness drives conducted? (Yes/No)","Are people cooperating? (Yes/No)","Are improvements visible? (Yes/No)","Are penalties enforced? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are ODF programs implemented? (Yes/No)","Is monitoring done? (Yes/No)","Are complaints addressed? (Yes/No)","Are improvements visible? (Yes/No)","Are policies effective? (Yes/No)","Are actions taken? (Yes/No)"] }
+  ],
+  "Poor Drainage & Wastewater Management": [
+    { stakeholder: "Households", count: 8, questions: ["Is drainage available? (Yes/No)","Is water stagnating near house? (Yes/No)","Do you face mosquito issues? (Yes/No)","Is drainage cleaned regularly? (Yes/No)","Do you dispose wastewater properly? (Yes/No)","Are drains blocked? (Yes/No)","Are foul smells common? (Yes/No)","Are conditions worsening? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are drains cleaned regularly? (Yes/No)","Is equipment sufficient? (Yes/No)","Are blockages frequent? (Yes/No)","Are complaints common? (Yes/No)","Is workload high? (Yes/No)","Are services effective? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Are drainage systems planned? (Yes/No)","Are cleaning schedules followed? (Yes/No)","Are funds sufficient? (Yes/No)","Are complaints addressed? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)"] }
+  ],
+  "Improper Solid & Liquid Waste Disposal": [
+    { stakeholder: "Households", count: 8, questions: ["Do you dispose waste properly? (Yes/No)","Do you dump waste openly? (Yes/No)","Is waste collected regularly? (Yes/No)","Do you segregate waste? (Yes/No)","Are bins available? (Yes/No)","Do you face waste accumulation? (Yes/No)","Is environment clean? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Is waste collected daily? (Yes/No)","Are tools sufficient? (Yes/No)","Is segregation practiced? (Yes/No)","Are complaints frequent? (Yes/No)","Is workload high? (Yes/No)","Are services effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is waste system implemented? (Yes/No)","Are services monitored? (Yes/No)","Are funds sufficient? (Yes/No)","Are complaints addressed? (Yes/No)","Are improvements planned? (Yes/No)","Is system efficient? (Yes/No)"] }
+  ],
+  "Lack of Hygiene Practices (Handwashing, Cleanliness)": [
+    { stakeholder: "Households", count: 8, questions: ["Do you wash hands regularly? (Yes/No)","Do you use soap? (Yes/No)","Do you follow hygiene practices? (Yes/No)","Are surroundings clean? (Yes/No)","Are toilets cleaned regularly? (Yes/No)","Do children follow hygiene? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are practices improving? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Do you wash hands before eating? (Yes/No)","Are hygiene lessons taught? (Yes/No)","Do you follow cleanliness? (Yes/No)","Are facilities available? (Yes/No)","Are programs conducted? (Yes/No)","Are habits improving? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are awareness sessions conducted? (Yes/No)","Are people following hygiene? (Yes/No)","Are diseases common? (Yes/No)","Are improvements visible? (Yes/No)","Are resources sufficient? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Water Storage & Contamination Issues": [
+    { stakeholder: "Households", count: 8, questions: ["Do you store water properly? (Yes/No)","Are containers clean? (Yes/No)","Do you cover stored water? (Yes/No)","Is contamination common? (Yes/No)","Do you clean containers regularly? (Yes/No)","Do you use safe storage methods? (Yes/No)","Are you aware of risks? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are storage practices safe? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are diseases linked to storage? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are practices monitored? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are awareness campaigns conducted? (Yes/No)","Are households educated? (Yes/No)","Are programs effective? (Yes/No)","Are improvements visible? (Yes/No)","Are policies implemented? (Yes/No)","Are systems monitored? (Yes/No)"] }
+  ],
+  "Poor Maintenance of Water & Sanitation Infrastructure": [
+    { stakeholder: "Workers", count: 6, questions: ["Are systems maintained regularly? (Yes/No)","Are repairs frequent? (Yes/No)","Are tools sufficient? (Yes/No)","Are breakdowns common? (Yes/No)","Is workload high? (Yes/No)","Are services effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is maintenance planned? (Yes/No)","Are funds sufficient? (Yes/No)","Are complaints addressed? (Yes/No)","Are inspections conducted? (Yes/No)","Are improvements ongoing? (Yes/No)","Is monitoring effective? (Yes/No)"] },
+    { stakeholder: "Households", count: 6, questions: ["Are facilities working properly? (Yes/No)","Do you face breakdown issues? (Yes/No)","Are repairs done quickly? (Yes/No)","Do you report issues? (Yes/No)","Are services reliable? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Low Community Awareness & Participation": [
+    { stakeholder: "Households", count: 8, questions: ["Are you aware of sanitation practices? (Yes/No)","Do you participate in programs? (Yes/No)","Are awareness campaigns conducted? (Yes/No)","Do you follow guidelines? (Yes/No)","Are you interested in learning? (Yes/No)","Are conditions improving? (Yes/No)","Are problems discussed? (Yes/No)","Are changes visible? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are discussions held? (Yes/No)","Are actions taken? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are campaigns conducted? (Yes/No)","Is awareness low? (Yes/No)","Are programs effective? (Yes/No)","Are materials distributed? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  // COMMUNITY ACTIONS
+  "Low Community Participation in Local Development Activities": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you participate in community activities? (Yes/No)","Do you attend meetings? (Yes/No)","Do you contribute to local development? (Yes/No)","Are activities organized regularly? (Yes/No)","Do you feel encouraged to participate? (Yes/No)","Are community programs useful? (Yes/No)","Are people interested in participation? (Yes/No)","Is participation low? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are meetings conducted regularly? (Yes/No)","Is participation high? (Yes/No)","Are people cooperative? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are community programs conducted? (Yes/No)","Is participation low? (Yes/No)","Are awareness drives effective? (Yes/No)","Are volunteers available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Lack of Volunteerism & Social Responsibility among Youth": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you volunteer in community work? (Yes/No)","Are you interested in social activities? (Yes/No)","Do you participate in campaigns? (Yes/No)","Do you feel responsible for society? (Yes/No)","Are opportunities available? (Yes/No)","Do you face time constraints? (Yes/No)","Are incentives needed? (Yes/No)","Is participation low? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Do you participate in social work? (Yes/No)","Are programs organized? (Yes/No)","Are you encouraged? (Yes/No)","Are activities useful? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are youth involved? (Yes/No)","Are programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Is participation increasing? (Yes/No)","Are incentives provided? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Poor Coordination between Community & Local Authorities": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you report issues to authorities? (Yes/No)","Are complaints addressed? (Yes/No)","Is communication effective? (Yes/No)","Do you trust authorities? (Yes/No)","Are services satisfactory? (Yes/No)","Do you face delays? (Yes/No)","Are meetings conducted? (Yes/No)","Is coordination poor? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are complaints received regularly? (Yes/No)","Are issues resolved quickly? (Yes/No)","Are meetings conducted? (Yes/No)","Is participation high? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Is coordination effective? (Yes/No)","Are discussions conducted? (Yes/No)","Are issues resolved? (Yes/No)","Are people cooperative? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Lack of Awareness on Civic Responsibilities": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of civic duties? (Yes/No)","Do you follow rules? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you participate in campaigns? (Yes/No)","Are people responsible? (Yes/No)","Are issues discussed? (Yes/No)","Is awareness low? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are civic topics taught? (Yes/No)","Do you follow rules? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you participate in activities? (Yes/No)","Are improvements needed? (Yes/No)","Are habits improving? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are campaigns conducted? (Yes/No)","Is participation high? (Yes/No)","Are programs effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)","Are materials distributed? (Yes/No)"] }
+  ],
+  "Low Participation in Cleanliness & Public Health Campaigns": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you participate in cleanliness drives? (Yes/No)","Do you keep surroundings clean? (Yes/No)","Are campaigns conducted? (Yes/No)","Are people cooperative? (Yes/No)","Are conditions clean? (Yes/No)","Are improvements needed? (Yes/No)","Are awareness programs conducted? (Yes/No)","Is participation low? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are drives conducted regularly? (Yes/No)","Are people cooperative? (Yes/No)","Is workload high? (Yes/No)","Are tools sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are campaigns organized? (Yes/No)","Is participation high? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are monitoring systems active? (Yes/No)"] }
+  ],
+  "Weak Community Response during Emergencies/Disasters": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you prepared for emergencies? (Yes/No)","Do you know emergency contacts? (Yes/No)","Are resources available? (Yes/No)","Do you participate in drills? (Yes/No)","Are support systems available? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are emergency plans prepared? (Yes/No)","Are drills conducted? (Yes/No)","Are resources sufficient? (Yes/No)","Are teams trained? (Yes/No)","Are responses effective? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Volunteers", count: 6, questions: ["Are volunteers available? (Yes/No)","Are they trained? (Yes/No)","Are resources sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Poor Inclusion of Women & Marginalized Groups in Community Activities": [
+    { stakeholder: "Women", count: 8, questions: ["Do you participate in community activities? (Yes/No)","Are you encouraged to participate? (Yes/No)","Do you face restrictions? (Yes/No)","Are your opinions considered? (Yes/No)","Do you attend meetings? (Yes/No)","Are opportunities equal? (Yes/No)","Do you feel included? (Yes/No)","Is participation low among women? (Yes/No)"] },
+    { stakeholder: "Marginalized Groups", count: 6, questions: ["Do you participate in community activities? (Yes/No)","Do you face discrimination? (Yes/No)","Are you included in decision-making? (Yes/No)","Are opportunities equal? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are women participating actively? (Yes/No)","Are marginalized groups included? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are barriers present? (Yes/No)","Are improvements visible? (Yes/No)","Are policies supportive? (Yes/No)"] }
+  ],
+  "Lack of Ownership of Public Infrastructure": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you take care of public property? (Yes/No)","Do you report damages? (Yes/No)","Do you misuse public facilities? (Yes/No)","Are facilities maintained properly? (Yes/No)","Do you feel responsible? (Yes/No)","Are damages frequent? (Yes/No)","Are improvements needed? (Yes/No)","Is ownership low? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are facilities maintained regularly? (Yes/No)","Are damages common? (Yes/No)","Are repairs frequent? (Yes/No)","Are tools sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are services effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are facilities monitored? (Yes/No)","Are complaints addressed? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are policies implemented? (Yes/No)","Is community involvement present? (Yes/No)"] }
+  ],
+  "Low Awareness of Government Programs & Community Schemes": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of government schemes? (Yes/No)","Do you use these schemes? (Yes/No)","Do you receive benefits? (Yes/No)","Are services accessible? (Yes/No)","Do you depend on others for information? (Yes/No)","Are awareness programs conducted? (Yes/No)","Is awareness low? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented properly? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are complaints frequent? (Yes/No)","Are improvements planned? (Yes/No)","Is monitoring effective? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are awareness campaigns conducted? (Yes/No)","Is participation high? (Yes/No)","Are programs effective? (Yes/No)","Are materials distributed? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Lack of Collective Problem-Solving & Decision-Making": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you participate in decision-making? (Yes/No)","Are meetings conducted regularly? (Yes/No)","Do you share your opinions? (Yes/No)","Are decisions transparent? (Yes/No)","Do you feel heard? (Yes/No)","Are problems discussed openly? (Yes/No)","Is participation low? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are meetings conducted regularly? (Yes/No)","Is participation high? (Yes/No)","Are decisions inclusive? (Yes/No)","Are conflicts present? (Yes/No)","Are solutions effective? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are community meetings conducted? (Yes/No)","Are issues addressed collectively? (Yes/No)","Is coordination effective? (Yes/No)","Are policies implemented? (Yes/No)","Are improvements visible? (Yes/No)","Are systems efficient? (Yes/No)"] }
+  ],
+  // RURAL / URBAN EDUCATION
+  "Low Student Attendance & Irregular Schooling": [
+    { stakeholder: "Students", count: 8, questions: ["Do you attend school regularly? (Yes/No)","Do you miss classes frequently? (Yes/No)","Do you enjoy attending school? (Yes/No)","Do you face any barriers to attend school? (Yes/No)","Are classes conducted regularly? (Yes/No)","Do you feel motivated to attend school? (Yes/No)","Do you help in household work instead of school? (Yes/No)","Is attendance low among your peers? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Does your child attend school regularly? (Yes/No)","Do you monitor attendance? (Yes/No)","Are there barriers to schooling? (Yes/No)","Do you support education? (Yes/No)","Are dropouts common? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students attending regularly? (Yes/No)","Is attendance low? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are parents cooperative? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "High Dropout Rates (Especially Secondary Level)": [
+    { stakeholder: "Students", count: 8, questions: ["Do students drop out after primary school? (Yes/No)","Do financial issues affect education? (Yes/No)","Do you plan to continue studies? (Yes/No)","Are dropouts common in your area? (Yes/No)","Do you face pressure to work? (Yes/No)","Are schools accessible? (Yes/No)","Are facilities adequate? (Yes/No)","Do you feel discouraged to study? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do children drop out early? (Yes/No)","Are financial issues a reason? (Yes/No)","Do you encourage higher education? (Yes/No)","Are schools accessible? (Yes/No)","Are girls more affected? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are dropout rates high? (Yes/No)","Are reasons identified? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are parents supportive? (Yes/No)","Are interventions effective? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Lack of Basic Learning Skills (Reading, Writing, Numeracy)": [
+    { stakeholder: "Students", count: 8, questions: ["Can you read basic text? (Yes/No)","Can you write properly? (Yes/No)","Can you solve basic math? (Yes/No)","Do you understand lessons? (Yes/No)","Do you need extra help? (Yes/No)","Are classes interactive? (Yes/No)","Are learning materials available? (Yes/No)","Do you feel learning is difficult? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Do students have basic skills? (Yes/No)","Are learning gaps present? (Yes/No)","Are remedial classes conducted? (Yes/No)","Are materials sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Can your child read/write? (Yes/No)","Do you support learning at home? (Yes/No)","Are learning difficulties present? (Yes/No)","Are schools effective? (Yes/No)","Are improvements needed? (Yes/No)","Are you satisfied? (Yes/No)"] }
+  ],
+  "Poor Teaching Quality & Lack of Teacher Training": [
+    { stakeholder: "Students", count: 7, questions: ["Are teachers regular? (Yes/No)","Do teachers explain clearly? (Yes/No)","Are classes interesting? (Yes/No)","Do teachers help students? (Yes/No)","Are doubts cleared? (Yes/No)","Are teaching methods effective? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are training programs conducted? (Yes/No)","Are teaching resources available? (Yes/No)","Are challenges present? (Yes/No)","Are classes interactive? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes satisfactory? (Yes/No)"] },
+    { stakeholder: "School Management", count: 6, questions: ["Are teachers monitored? (Yes/No)","Are trainings conducted? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are complaints addressed? (Yes/No)","Are systems effective? (Yes/No)"] }
+  ],
+  "Limited Access to Digital Education & ICT Tools": [
+    { stakeholder: "Students", count: 7, questions: ["Do you use digital tools? (Yes/No)","Are online classes available? (Yes/No)","Do you have internet access? (Yes/No)","Do you face difficulties? (Yes/No)","Are devices available? (Yes/No)","Is digital learning helpful? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Do you use digital tools? (Yes/No)","Are you trained in ICT? (Yes/No)","Are facilities available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are students engaged? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are ICT labs available? (Yes/No)","Are devices sufficient? (Yes/No)","Is internet available? (Yes/No)","Are programs implemented? (Yes/No)","Are upgrades planned? (Yes/No)","Are systems effective? (Yes/No)"] }
+  ],
+  "Lack of Parental Involvement in Education": [
+    { stakeholder: "Parents", count: 8, questions: ["Do you monitor studies? (Yes/No)","Do you attend school meetings? (Yes/No)","Do you support homework? (Yes/No)","Are you aware of child performance? (Yes/No)","Do you encourage education? (Yes/No)","Are you involved in decisions? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are parents involved? (Yes/No)","Are meetings conducted? (Yes/No)","Are parents cooperative? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes better? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Do parents support studies? (Yes/No)","Do parents monitor progress? (Yes/No)","Do parents attend meetings? (Yes/No)","Do you get help at home? (Yes/No)","Are parents encouraging? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Inadequate School Infrastructure (Classrooms, Toilets, Facilities)": [
+    { stakeholder: "Students", count: 8, questions: ["Are classrooms sufficient? (Yes/No)","Are toilets available? (Yes/No)","Is drinking water available? (Yes/No)","Are classrooms clean? (Yes/No)","Are facilities adequate? (Yes/No)","Is school safe? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are facilities sufficient? (Yes/No)","Are classrooms adequate? (Yes/No)","Are resources available? (Yes/No)","Are maintenance issues present? (Yes/No)","Are improvements needed? (Yes/No)","Are complaints addressed? (Yes/No)"] },
+    { stakeholder: "School Management", count: 6, questions: ["Are facilities maintained? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are inspections conducted? (Yes/No)","Are systems effective? (Yes/No)","Are issues resolved? (Yes/No)"] }
+  ],
+  "Gender Disparities in Education": [
+    { stakeholder: "Students", count: 7, questions: ["Are boys and girls treated equally? (Yes/No)","Do girls attend regularly? (Yes/No)","Are opportunities equal? (Yes/No)","Are dropouts higher among girls? (Yes/No)","Are facilities adequate? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you support girls' education? (Yes/No)","Are barriers present? (Yes/No)","Are girls encouraged? (Yes/No)","Are opportunities equal? (Yes/No)","Are traditions affecting education? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are girls attending regularly? (Yes/No)","Are gaps present? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Lack of Career Awareness & Guidance": [
+    { stakeholder: "Students", count: 7, questions: ["Do you know career options? (Yes/No)","Do you receive guidance? (Yes/No)","Are sessions conducted? (Yes/No)","Do you have career goals? (Yes/No)","Do you feel confused? (Yes/No)","Are opportunities known? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are career sessions conducted? (Yes/No)","Are students aware? (Yes/No)","Are materials available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are you aware of career options? (Yes/No)","Do you guide your child? (Yes/No)","Are opportunities known? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)","Are you supportive? (Yes/No)"] }
+  ],
+  "Limited Access to Higher Education Opportunities": [
+    { stakeholder: "Students", count: 8, questions: ["Do you plan higher education? (Yes/No)","Are colleges accessible? (Yes/No)","Are financial issues present? (Yes/No)","Are scholarships known? (Yes/No)","Are guidance programs available? (Yes/No)","Are barriers present? (Yes/No)","Are opportunities equal? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you support higher education? (Yes/No)","Are financial issues present? (Yes/No)","Are opportunities known? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)","Are you supportive? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are scholarships provided? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  // SKILL IDENTIFICATION & DEVELOPMENT
+  "Lack of Awareness of Individual Skills & Talents": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you know your strengths/skills? (Yes/No)","Have you identified your interests? (Yes/No)","Do you explore new skills? (Yes/No)","Do you feel confused about your abilities? (Yes/No)","Are skill awareness programs available? (Yes/No)","Do you want to learn new skills? (Yes/No)","Do you receive guidance? (Yes/No)","Is awareness low among peers? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are you aware of your child's skills? (Yes/No)","Do you support skill development? (Yes/No)","Do you guide career choices? (Yes/No)","Are opportunities known? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are assessment programs conducted? (Yes/No)","Are students aware of skills? (Yes/No)","Are tools available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Skill-Career Mismatch": [
+    { stakeholder: "Youth", count: 8, questions: ["Are your skills aligned with career goals? (Yes/No)","Do you know job requirements? (Yes/No)","Do you feel unprepared for jobs? (Yes/No)","Are training programs relevant? (Yes/No)","Do you face difficulty getting jobs? (Yes/No)","Are career options clear? (Yes/No)","Do you receive guidance? (Yes/No)","Is mismatch common? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are candidates skilled? (Yes/No)","Are skills industry-relevant? (Yes/No)","Do candidates need retraining? (Yes/No)","Are gaps present? (Yes/No)","Are improvements needed? (Yes/No)","Is demand unmet? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are courses aligned with industry? (Yes/No)","Are updates frequent? (Yes/No)","Are students job-ready? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are placements successful? (Yes/No)"] }
+  ],
+  "Limited Access to Skill Development Programs": [
+    { stakeholder: "Youth", count: 8, questions: ["Are training centers available? (Yes/No)","Are programs accessible? (Yes/No)","Are costs affordable? (Yes/No)","Do you attend programs? (Yes/No)","Are programs relevant? (Yes/No)","Are barriers present? (Yes/No)","Are opportunities known? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Training Centers", count: 6, questions: ["Are programs conducted regularly? (Yes/No)","Is participation high? (Yes/No)","Are resources sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are funds sufficient? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)"] }
+  ],
+  "Lack of Practical/Hands-on Training": [
+    { stakeholder: "Students", count: 8, questions: ["Do you receive practical training? (Yes/No)","Are hands-on sessions conducted? (Yes/No)","Are labs/workshops available? (Yes/No)","Do you feel confident in skills? (Yes/No)","Do you need more practice? (Yes/No)","Are facilities adequate? (Yes/No)","Are opportunities sufficient? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are practical sessions conducted? (Yes/No)","Are tools available? (Yes/No)","Are students engaged? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are candidates practically skilled? (Yes/No)","Do they require training? (Yes/No)","Are gaps present? (Yes/No)","Are expectations met? (Yes/No)","Are improvements needed? (Yes/No)","Are hiring challenges present? (Yes/No)"] }
+  ],
+  "Low Communication & Confidence Skills": [
+    { stakeholder: "Students", count: 8, questions: ["Do you feel confident speaking? (Yes/No)","Do you face hesitation? (Yes/No)","Are communication skills taught? (Yes/No)","Do you participate in discussions? (Yes/No)","Are opportunities available? (Yes/No)","Do you need improvement? (Yes/No)","Are training programs conducted? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are communication skills taught? (Yes/No)","Are students confident? (Yes/No)","Are programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are candidates confident? (Yes/No)","Are communication skills adequate? (Yes/No)","Are gaps present? (Yes/No)","Are improvements needed? (Yes/No)","Are training programs needed? (Yes/No)","Are hiring challenges present? (Yes/No)"] }
+  ],
+  "Limited Awareness of Career Options": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you know career options? (Yes/No)","Do you have career goals? (Yes/No)","Do you receive guidance? (Yes/No)","Are sessions conducted? (Yes/No)","Are opportunities known? (Yes/No)","Do you feel confused? (Yes/No)","Are programs available? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are you aware of career options? (Yes/No)","Do you guide your child? (Yes/No)","Are opportunities known? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)","Are you supportive? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are career sessions conducted? (Yes/No)","Are students aware? (Yes/No)","Are materials available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Lack of Industry-Relevant Skills": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you have job-relevant skills? (Yes/No)","Are skills aligned with industry needs? (Yes/No)","Do you feel job-ready? (Yes/No)","Are training programs relevant? (Yes/No)","Do you need additional skills? (Yes/No)","Are opportunities available? (Yes/No)","Are gaps present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are candidates industry-ready? (Yes/No)","Are skills adequate? (Yes/No)","Are gaps present? (Yes/No)","Are expectations met? (Yes/No)","Are improvements needed? (Yes/No)","Are hiring challenges present? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are courses industry-aligned? (Yes/No)","Are updates frequent? (Yes/No)","Are outcomes effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are placements successful? (Yes/No)"] }
+  ],
+  "Financial Barriers to Skill Training": [
+    { stakeholder: "Youth", count: 8, questions: ["Are training programs costly? (Yes/No)","Do financial issues affect learning? (Yes/No)","Do you skip programs due to cost? (Yes/No)","Are scholarships available? (Yes/No)","Are opportunities accessible? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)","Are support systems available? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are financial issues present? (Yes/No)","Do you support training expenses? (Yes/No)","Are programs affordable? (Yes/No)","Are scholarships known? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)"] }
+  ],
+  "Gender Barriers in Skill Development": [
+    { stakeholder: "Women", count: 8, questions: ["Do you face barriers in skill learning? (Yes/No)","Are opportunities equal? (Yes/No)","Do you receive support? (Yes/No)","Are training programs accessible? (Yes/No)","Are restrictions present? (Yes/No)","Are facilities adequate? (Yes/No)","Are improvements needed? (Yes/No)","Are conditions improving? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you support girls' skill development? (Yes/No)","Are barriers present? (Yes/No)","Are opportunities equal? (Yes/No)","Are traditions affecting decisions? (Yes/No)","Are improvements needed? (Yes/No)","Are you supportive? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are women participating? (Yes/No)","Are barriers present? (Yes/No)","Are programs inclusive? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Lack of Mentorship & Guidance": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you have a mentor? (Yes/No)","Do you receive guidance? (Yes/No)","Are mentors available? (Yes/No)","Do you feel supported? (Yes/No)","Are guidance programs conducted? (Yes/No)","Do you face confusion? (Yes/No)","Are opportunities known? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Mentors", count: 6, questions: ["Are mentorship programs conducted? (Yes/No)","Are students engaged? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)","Are improvements needed? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Institutions", count: 6, questions: ["Are mentorship systems implemented? (Yes/No)","Are programs conducted? (Yes/No)","Are students supported? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  // SPORTS & WELLNESS ENGAGEMENT
+  "Low Participation in Sports & Physical Activities": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you participate in sports regularly? (Yes/No)","Do you have time for sports? (Yes/No)","Do you enjoy physical activity? (Yes/No)","Are facilities available? (Yes/No)","Are you encouraged to play? (Yes/No)","Do you prefer screens over sports? (Yes/No)","Are opportunities available? (Yes/No)","Is participation low among peers? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do your children play sports? (Yes/No)","Do you encourage participation? (Yes/No)","Are facilities available? (Yes/No)","Are barriers present? (Yes/No)","Are academics affecting sports? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Coaches", count: 6, questions: ["Are students participating actively? (Yes/No)","Are facilities sufficient? (Yes/No)","Are programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Lack of Awareness about Health & Fitness": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you know importance of fitness? (Yes/No)","Do you exercise regularly? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you follow healthy habits? (Yes/No)","Are resources available? (Yes/No)","Do you understand risks? (Yes/No)","Are improvements needed? (Yes/No)","Are habits healthy? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Are lifestyle diseases common? (Yes/No)","Are people aware of fitness? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are sessions conducted? (Yes/No)","Are people participating? (Yes/No)","Are programs effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Inadequate Sports Infrastructure": [
+    { stakeholder: "Students", count: 8, questions: ["Are playgrounds available? (Yes/No)","Are facilities adequate? (Yes/No)","Is equipment available? (Yes/No)","Are grounds maintained? (Yes/No)","Do you face access issues? (Yes/No)","Are improvements needed? (Yes/No)","Are facilities safe? (Yes/No)","Is usage high? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are facilities provided? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are complaints addressed? (Yes/No)","Are monitoring systems active? (Yes/No)","Are programs implemented? (Yes/No)"] },
+    { stakeholder: "Coaches", count: 6, questions: ["Are facilities sufficient? (Yes/No)","Is equipment adequate? (Yes/No)","Are maintenance issues present? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are programs effective? (Yes/No)"] }
+  ],
+  "Poor Physical Fitness Levels": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you exercise regularly? (Yes/No)","Do you feel physically fit? (Yes/No)","Do you get tired easily? (Yes/No)","Are habits healthy? (Yes/No)","Do you participate in sports? (Yes/No)","Are improvements needed? (Yes/No)","Are facilities available? (Yes/No)","Do you follow fitness routines? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are youth physically fit? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are programs effective? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are fitness issues common? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "High Screen Time & Sedentary Lifestyle": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you spend more time on screens? (Yes/No)","Do you avoid physical activity? (Yes/No)","Do you play outdoor games? (Yes/No)","Are habits unhealthy? (Yes/No)","Are you aware of risks? (Yes/No)","Are alternatives available? (Yes/No)","Are improvements needed? (Yes/No)","Is screen time high? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do children spend more time on screens? (Yes/No)","Do you monitor usage? (Yes/No)","Do you encourage outdoor play? (Yes/No)","Are habits unhealthy? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students addicted to screens? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are habits affecting performance? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are interventions effective? (Yes/No)"] }
+  ],
+  "Lack of Organized Sports Programs": [
+    { stakeholder: "Students", count: 7, questions: ["Are sports events conducted? (Yes/No)","Do you participate in competitions? (Yes/No)","Are opportunities available? (Yes/No)","Are events regular? (Yes/No)","Are programs engaging? (Yes/No)","Are improvements needed? (Yes/No)","Are facilities adequate? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are sports programs conducted? (Yes/No)","Are facilities adequate? (Yes/No)","Are funds sufficient? (Yes/No)","Are students encouraged? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Coaches", count: 6, questions: ["Are events organized regularly? (Yes/No)","Are students participating? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are programs effective? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  "Gender Barriers in Sports Participation": [
+    { stakeholder: "Girls/Women", count: 8, questions: ["Do you participate in sports? (Yes/No)","Are opportunities equal? (Yes/No)","Do you face restrictions? (Yes/No)","Are facilities safe? (Yes/No)","Do you receive support? (Yes/No)","Are programs accessible? (Yes/No)","Are improvements needed? (Yes/No)","Are conditions improving? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you support girls' participation? (Yes/No)","Are barriers present? (Yes/No)","Are opportunities equal? (Yes/No)","Are facilities safe? (Yes/No)","Are improvements needed? (Yes/No)","Are you supportive? (Yes/No)"] },
+    { stakeholder: "Coaches", count: 6, questions: ["Are girls participating? (Yes/No)","Are barriers present? (Yes/No)","Are programs inclusive? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Lack of Access to Professional Coaching": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you have access to coaches? (Yes/No)","Are coaching programs available? (Yes/No)","Are costs affordable? (Yes/No)","Do you receive guidance? (Yes/No)","Are opportunities sufficient? (Yes/No)","Do you want professional training? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Coaches", count: 6, questions: ["Are coaching programs available? (Yes/No)","Are students participating? (Yes/No)","Are resources sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are coaching programs supported? (Yes/No)","Are funds sufficient? (Yes/No)","Are facilities provided? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Poor Nutrition & Lifestyle Habits": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you follow a healthy diet? (Yes/No)","Do you eat junk food regularly? (Yes/No)","Are you aware of nutrition? (Yes/No)","Do you consume fruits/vegetables? (Yes/No)","Are habits healthy? (Yes/No)","Do you skip meals? (Yes/No)","Are improvements needed? (Yes/No)","Are you physically active? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you provide healthy food? (Yes/No)","Are children eating junk food? (Yes/No)","Are habits monitored? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are you aware of nutrition? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are nutrition issues common? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Mental Health & Stress Issues": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you feel stressed often? (Yes/No)","Do you feel pressure from studies? (Yes/No)","Do you share problems with others? (Yes/No)","Do you participate in stress-relieving activities? (Yes/No)","Are support systems available? (Yes/No)","Are you aware of mental health? (Yes/No)","Do you feel anxious? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students stressed? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are counseling services available? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are interventions effective? (Yes/No)"] },
+    { stakeholder: "Health Professionals", count: 6, questions: ["Are mental health issues common? (Yes/No)","Are services accessible? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  // GREEN INNOVATIONS & TREE PLANTATION
+  "Low Tree Cover in Villages/Urban Areas": [
+    { stakeholder: "Residents", count: 8, questions: ["Are there enough trees in your area? (Yes/No)","Has tree cover decreased? (Yes/No)","Do you participate in planting? (Yes/No)","Are plantation drives conducted? (Yes/No)","Are spaces available for planting? (Yes/No)","Do you feel greenery is low? (Yes/No)","Are improvements needed? (Yes/No)","Are trees being protected? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are plantation programs implemented? (Yes/No)","Are targets achieved? (Yes/No)","Are funds sufficient? (Yes/No)","Are monitoring systems active? (Yes/No)","Are improvements planned? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Farmers", count: 6, questions: ["Are trees decreasing in farmland? (Yes/No)","Do you plant trees regularly? (Yes/No)","Are benefits known? (Yes/No)","Are challenges present? (Yes/No)","Are incentives available? (Yes/No)","Are improvements needed? (Yes/No)"] }
+  ],
+  "Lack of Awareness on Environmental Conservation": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of environmental issues? (Yes/No)","Do you follow eco-friendly practices? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you participate in campaigns? (Yes/No)","Are problems discussed? (Yes/No)","Is awareness low? (Yes/No)","Are improvements needed? (Yes/No)","Are habits changing? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are environmental topics taught? (Yes/No)","Do you participate in activities? (Yes/No)","Are programs conducted? (Yes/No)","Are you aware of climate issues? (Yes/No)","Are improvements needed? (Yes/No)","Are habits improving? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are campaigns conducted? (Yes/No)","Is participation high? (Yes/No)","Are programs effective? (Yes/No)","Are materials distributed? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Poor Survival Rate of Planted Trees": [
+    { stakeholder: "Residents", count: 8, questions: ["Do planted trees survive? (Yes/No)","Are plants watered regularly? (Yes/No)","Are trees protected? (Yes/No)","Are maintenance practices followed? (Yes/No)","Are plants damaged? (Yes/No)","Are improvements needed? (Yes/No)","Are survival rates low? (Yes/No)","Are responsibilities assigned? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are plants maintained regularly? (Yes/No)","Is watering sufficient? (Yes/No)","Are tools available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are survival rates monitored? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are survival rates tracked? (Yes/No)","Are funds sufficient? (Yes/No)","Are maintenance systems active? (Yes/No)","Are improvements planned? (Yes/No)","Are outcomes effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Lack of Community Participation in Plantation Drives": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you participate in plantation drives? (Yes/No)","Are programs conducted regularly? (Yes/No)","Are you encouraged to participate? (Yes/No)","Do you take responsibility for plants? (Yes/No)","Are awareness programs conducted? (Yes/No)","Is participation low? (Yes/No)","Are improvements needed? (Yes/No)","Are people interested? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are community drives conducted? (Yes/No)","Is participation high? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are actions taken? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are plantation drives conducted? (Yes/No)","Is participation high? (Yes/No)","Are programs effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  "Deforestation & Loss of Green Spaces": [
+    { stakeholder: "Residents", count: 8, questions: ["Are trees being cut frequently? (Yes/No)","Is green cover reducing? (Yes/No)","Are regulations followed? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are alternatives available? (Yes/No)","Are improvements needed? (Yes/No)","Are actions taken? (Yes/No)","Are problems increasing? (Yes/No)"] },
+    { stakeholder: "Farmers", count: 6, questions: ["Do you cut trees for farming? (Yes/No)","Are alternatives available? (Yes/No)","Are benefits of trees known? (Yes/No)","Are incentives provided? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are regulations implemented? (Yes/No)","Are violations monitored? (Yes/No)","Are penalties enforced? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Lack of Watering & Maintenance for Plants": [
+    { stakeholder: "Residents", count: 8, questions: ["Are plants watered regularly? (Yes/No)","Do you take responsibility? (Yes/No)","Are plants maintained? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are plants damaged? (Yes/No)","Are systems available? (Yes/No)","Are efforts sufficient? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Is watering done regularly? (Yes/No)","Are tools available? (Yes/No)","Are plants maintained? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are students involved in maintenance? (Yes/No)","Are programs conducted? (Yes/No)","Are awareness sessions held? (Yes/No)","Are plants maintained? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Limited Use of Eco-Friendly Innovations (Rainwater Harvesting, Composting, etc.)": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you practice composting? (Yes/No)","Do you use eco-friendly methods? (Yes/No)","Are innovations known? (Yes/No)","Are systems available? (Yes/No)","Are improvements needed? (Yes/No)","Are practices followed? (Yes/No)","Are benefits known? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are eco-friendly methods taught? (Yes/No)","Do you practice them? (Yes/No)","Are programs conducted? (Yes/No)","Are innovations known? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are programs implemented? (Yes/No)","Are incentives provided? (Yes/No)","Are systems effective? (Yes/No)","Are improvements planned? (Yes/No)","Are challenges present? (Yes/No)","Are awareness programs conducted? (Yes/No)"] }
+  ],
+  "Waste Generation Affecting Environment": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you dispose waste properly? (Yes/No)","Do you segregate waste? (Yes/No)","Are bins available? (Yes/No)","Is waste affecting environment? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are surroundings clean? (Yes/No)","Are habits improving? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Is waste collected regularly? (Yes/No)","Is segregation practiced? (Yes/No)","Are tools sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are systems implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are complaints addressed? (Yes/No)","Are monitoring systems active? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Lack of School-Level Environmental Education": [
+    { stakeholder: "Students", count: 6, questions: ["Are environmental topics taught? (Yes/No)","Do you participate in activities? (Yes/No)","Are programs conducted? (Yes/No)","Are you aware of climate issues? (Yes/No)","Are improvements needed? (Yes/No)","Are habits improving? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are topics included in curriculum? (Yes/No)","Are activities conducted? (Yes/No)","Are students interested? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are programs implemented? (Yes/No)","Are facilities available? (Yes/No)","Are improvements planned? (Yes/No)","Are awareness sessions conducted? (Yes/No)","Are systems effective? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Climate Change Awareness & Local Action Gap": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of climate change? (Yes/No)","Do you take action locally? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are problems increasing? (Yes/No)","Are improvements needed? (Yes/No)","Are actions effective? (Yes/No)","Are habits changing? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Are you aware of climate change? (Yes/No)","Do you participate in activities? (Yes/No)","Are programs conducted? (Yes/No)","Are actions effective? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are climate programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are programs effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  // MENTAL HEALTH & WELL-BEING
+  "Low Awareness about Mental Health": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you know about mental health? (Yes/No)","Are you aware of common issues (stress, anxiety)? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you understand the importance of mental health? (Yes/No)","Do you talk openly about mental health? (Yes/No)","Are resources available? (Yes/No)","Is awareness low among peers? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are you aware of mental health issues? (Yes/No)","Do you discuss mental health with children? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are problems recognized early? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Are people aware of mental health? (Yes/No)","Are cases increasing? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements visible? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "High Stress & Anxiety among Students/Youth": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you feel stressed frequently? (Yes/No)","Do you experience anxiety? (Yes/No)","Is stress due to studies/work? (Yes/No)","Do you have coping methods? (Yes/No)","Do you share problems with others? (Yes/No)","Are support systems available? (Yes/No)","Are stress levels increasing? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students stressed? (Yes/No)","Are stress levels increasing? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are counseling services available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do children feel stressed? (Yes/No)","Do you notice anxiety? (Yes/No)","Do you provide support? (Yes/No)","Are pressures high? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Social Stigma around Mental Health": [
+    { stakeholder: "Youth", count: 8, questions: ["Do people hesitate to talk about mental health? (Yes/No)","Are people afraid of judgment? (Yes/No)","Is stigma present in society? (Yes/No)","Do you feel comfortable discussing issues? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are attitudes improving? (Yes/No)","Are problems hidden? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do people avoid discussing mental health? (Yes/No)","Are issues ignored? (Yes/No)","Are beliefs negative? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are attitudes changing? (Yes/No)"] },
+    { stakeholder: "Community Leaders", count: 6, questions: ["Is stigma common? (Yes/No)","Are awareness campaigns conducted? (Yes/No)","Are attitudes improving? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are actions taken? (Yes/No)"] }
+  ],
+  "Lack of Access to Counseling & Support Services": [
+    { stakeholder: "Youth", count: 8, questions: ["Are counseling services available? (Yes/No)","Do you know where to seek help? (Yes/No)","Are services affordable? (Yes/No)","Do you feel comfortable seeking help? (Yes/No)","Are barriers present? (Yes/No)","Are services accessible? (Yes/No)","Are improvements needed? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Health Professionals", count: 6, questions: ["Are services available? (Yes/No)","Are cases increasing? (Yes/No)","Are resources sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are counseling services available? (Yes/No)","Are students supported? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Academic Pressure & Performance Stress": [
+    { stakeholder: "Students", count: 8, questions: ["Do you feel pressure to perform? (Yes/No)","Are expectations high? (Yes/No)","Do exams cause stress? (Yes/No)","Are support systems available? (Yes/No)","Do you feel overwhelmed? (Yes/No)","Are improvements needed? (Yes/No)","Are pressures increasing? (Yes/No)","Are coping methods available? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do you expect high performance? (Yes/No)","Are children stressed? (Yes/No)","Do you provide support? (Yes/No)","Are pressures high? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students under pressure? (Yes/No)","Are support systems available? (Yes/No)","Are improvements needed? (Yes/No)","Are programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Work-Life Imbalance (Youth/Adults)": [
+    { stakeholder: "Youth/Employees", count: 8, questions: ["Do you manage time well? (Yes/No)","Do you feel overworked? (Yes/No)","Do you have time for relaxation? (Yes/No)","Are work pressures high? (Yes/No)","Are support systems available? (Yes/No)","Are improvements needed? (Yes/No)","Are stress levels high? (Yes/No)","Are work hours long? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are employees overworked? (Yes/No)","Are support systems available? (Yes/No)","Are policies supportive? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Families", count: 6, questions: ["Do family members feel stressed? (Yes/No)","Are work pressures affecting life? (Yes/No)","Are support systems available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are relationships affected? (Yes/No)"] }
+  ],
+  "Lack of Emotional Support Systems": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you have someone to talk to? (Yes/No)","Do you share problems? (Yes/No)","Are support systems available? (Yes/No)","Do you feel emotionally supported? (Yes/No)","Are relationships strong? (Yes/No)","Are improvements needed? (Yes/No)","Are issues ignored? (Yes/No)","Are support systems weak? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Do children share problems? (Yes/No)","Do you provide emotional support? (Yes/No)","Are relationships strong? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are communication gaps present? (Yes/No)"] },
+    { stakeholder: "Friends", count: 6, questions: ["Do friends support each other? (Yes/No)","Do people share problems? (Yes/No)","Are relationships strong? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are issues ignored? (Yes/No)"] }
+  ],
+  "Substance Abuse & Addictive Behaviors": [
+    { stakeholder: "Youth", count: 8, questions: ["Is substance use common? (Yes/No)","Do you see peer influence? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are risks known? (Yes/No)","Are habits increasing? (Yes/No)","Are support systems available? (Yes/No)","Are improvements needed? (Yes/No)","Are alternatives available? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are children exposed to substances? (Yes/No)","Are habits increasing? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are support systems available? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are substance abuse cases common? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are interventions effective? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  "Social Isolation & Loneliness": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you feel lonely? (Yes/No)","Do you have social connections? (Yes/No)","Are you socially active? (Yes/No)","Are relationships strong? (Yes/No)","Are support systems available? (Yes/No)","Are improvements needed? (Yes/No)","Are interactions low? (Yes/No)","Are issues increasing? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are children socially active? (Yes/No)","Do they feel isolated? (Yes/No)","Are relationships strong? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are support systems available? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students isolated? (Yes/No)","Are interactions low? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are interventions effective? (Yes/No)"] }
+  ],
+  "Lack of Mental Health Programs in Community/Schools": [
+    { stakeholder: "Students", count: 6, questions: ["Are mental health programs conducted? (Yes/No)","Are awareness sessions available? (Yes/No)","Are counseling services available? (Yes/No)","Are improvements needed? (Yes/No)","Are programs effective? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Schools", count: 6, questions: ["Are programs implemented? (Yes/No)","Are resources available? (Yes/No)","Are students supported? (Yes/No)","Are improvements needed? (Yes/No)","Are systems effective? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are programs implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  // LIVELIHOOD & ENTREPRENEURSHIP
+  "Lack of Awareness about Livelihood Opportunities": [
+    { stakeholder: "Youth", count: 8, questions: ["Are you aware of livelihood opportunities? (Yes/No)","Do you know different job options? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you receive guidance? (Yes/No)","Are opportunities available locally? (Yes/No)","Do you feel confused about careers? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are you aware of livelihood options? (Yes/No)","Do you guide your children? (Yes/No)","Are opportunities known? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)","Are you supportive? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are schemes implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Limited Access to Skill-Based Employment": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you have employable skills? (Yes/No)","Are jobs available locally? (Yes/No)","Do you face difficulty getting jobs? (Yes/No)","Are training programs available? (Yes/No)","Are skills relevant to jobs? (Yes/No)","Are opportunities sufficient? (Yes/No)","Are gaps present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are skilled workers available? (Yes/No)","Are candidates job-ready? (Yes/No)","Are skill gaps present? (Yes/No)","Are hiring challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are training programs needed? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are programs conducted regularly? (Yes/No)","Are students job-ready? (Yes/No)","Are courses industry-relevant? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Lack of Entrepreneurship Awareness & Motivation": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you know about entrepreneurship? (Yes/No)","Do you want to start a business? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you have business ideas? (Yes/No)","Do you receive guidance? (Yes/No)","Are opportunities available? (Yes/No)","Are barriers present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Entrepreneurs", count: 6, questions: ["Are youth interested in business? (Yes/No)","Are support systems available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are opportunities sufficient? (Yes/No)","Are programs effective? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are entrepreneurship programs conducted? (Yes/No)","Are students interested? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Limited Access to Financial Support (Loans/Subsidies)": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you know about loans/subsidies? (Yes/No)","Are financial resources accessible? (Yes/No)","Are procedures easy? (Yes/No)","Do you face financial barriers? (Yes/No)","Are schemes known? (Yes/No)","Are improvements needed? (Yes/No)","Are support systems available? (Yes/No)","Are opportunities sufficient? (Yes/No)"] },
+    { stakeholder: "Banks", count: 6, questions: ["Are loans provided easily? (Yes/No)","Are applicants eligible? (Yes/No)","Are procedures simple? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Lack of Market Linkages for Local Products": [
+    { stakeholder: "Entrepreneurs", count: 8, questions: ["Do you have access to markets? (Yes/No)","Are products sold easily? (Yes/No)","Are digital platforms used? (Yes/No)","Are profits sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are opportunities sufficient? (Yes/No)","Are support systems available? (Yes/No)"] },
+    { stakeholder: "Customers", count: 6, questions: ["Are local products available? (Yes/No)","Do you purchase local products? (Yes/No)","Are prices reasonable? (Yes/No)","Are products of good quality? (Yes/No)","Are improvements needed? (Yes/No)","Are options sufficient? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are market linkages supported? (Yes/No)","Are programs implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Low Digital Literacy for Business Activities": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you use digital tools for work? (Yes/No)","Are online platforms known? (Yes/No)","Are training programs available? (Yes/No)","Do you face difficulties? (Yes/No)","Are opportunities available? (Yes/No)","Are improvements needed? (Yes/No)","Are resources sufficient? (Yes/No)","Are skills adequate? (Yes/No)"] },
+    { stakeholder: "Entrepreneurs", count: 6, questions: ["Do you use digital platforms? (Yes/No)","Are online sales possible? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are skills sufficient? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are programs conducted? (Yes/No)","Are participants interested? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Lack of Training & Capacity Building Programs": [
+    { stakeholder: "Youth", count: 8, questions: ["Are training programs available? (Yes/No)","Do you attend training? (Yes/No)","Are programs relevant? (Yes/No)","Are skills improved? (Yes/No)","Are opportunities available? (Yes/No)","Are improvements needed? (Yes/No)","Are barriers present? (Yes/No)","Are outcomes useful? (Yes/No)"] },
+    { stakeholder: "Training Centers", count: 6, questions: ["Are programs conducted regularly? (Yes/No)","Is participation high? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are programs implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Gender Barriers in Livelihood Opportunities": [
+    { stakeholder: "Women", count: 8, questions: ["Do you have access to livelihood opportunities? (Yes/No)","Are opportunities equal? (Yes/No)","Do you face restrictions? (Yes/No)","Are training programs accessible? (Yes/No)","Are financial resources available? (Yes/No)","Are improvements needed? (Yes/No)","Are conditions improving? (Yes/No)","Are support systems available? (Yes/No)"] },
+    { stakeholder: "Families", count: 6, questions: ["Do you support women working? (Yes/No)","Are barriers present? (Yes/No)","Are opportunities equal? (Yes/No)","Are improvements needed? (Yes/No)","Are traditions affecting decisions? (Yes/No)","Are you supportive? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are programs inclusive? (Yes/No)","Are women beneficiaries covered? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Unemployment among Youth": [
+    { stakeholder: "Youth", count: 8, questions: ["Are you unemployed? (Yes/No)","Are job opportunities available? (Yes/No)","Do you face difficulty finding jobs? (Yes/No)","Are skills sufficient? (Yes/No)","Are training programs available? (Yes/No)","Are improvements needed? (Yes/No)","Are opportunities limited? (Yes/No)","Are barriers present? (Yes/No)"] },
+    { stakeholder: "Employers", count: 6, questions: ["Are jobs available? (Yes/No)","Are candidates skilled? (Yes/No)","Are skill gaps present? (Yes/No)","Are hiring challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are training programs needed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are employment programs implemented? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Mentorship & Business Guidance": [
+    { stakeholder: "Youth", count: 8, questions: ["Do you have a mentor? (Yes/No)","Do you receive guidance? (Yes/No)","Are mentorship programs available? (Yes/No)","Do you feel supported? (Yes/No)","Are opportunities known? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are programs effective? (Yes/No)"] },
+    { stakeholder: "Mentors", count: 6, questions: ["Are mentorship programs conducted? (Yes/No)","Are youth engaged? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Institutions", count: 6, questions: ["Are mentorship systems implemented? (Yes/No)","Are programs conducted? (Yes/No)","Are youth supported? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  // CULTURAL HERITAGE & NARRATIVES
+  "Loss of Traditional Knowledge & Practices": [
+    { stakeholder: "Elders", count: 8, questions: ["Do you possess traditional knowledge? (Yes/No)","Are traditions being followed? (Yes/No)","Are youth learning traditions? (Yes/No)","Are practices declining? (Yes/No)","Are efforts made to preserve knowledge? (Yes/No)","Are cultural values changing? (Yes/No)","Are improvements needed? (Yes/No)","Are traditions documented? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Are you aware of traditions? (Yes/No)","Do you learn from elders? (Yes/No)","Are traditions interesting to you? (Yes/No)","Are opportunities available to learn? (Yes/No)","Are improvements needed? (Yes/No)","Are traditions declining? (Yes/No)"] },
+    { stakeholder: "Community Leaders", count: 6, questions: ["Are programs conducted? (Yes/No)","Are traditions preserved? (Yes/No)","Are youth involved? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are efforts effective? (Yes/No)"] }
+  ],
+  "Decline in Interest among Youth towards Culture": [
+    { stakeholder: "Youth", count: 8, questions: ["Are you interested in cultural activities? (Yes/No)","Do you participate in festivals/events? (Yes/No)","Are cultural programs available? (Yes/No)","Do you prefer modern entertainment? (Yes/No)","Are traditions relevant to you? (Yes/No)","Are opportunities available? (Yes/No)","Are improvements needed? (Yes/No)","Is interest declining? (Yes/No)"] },
+    { stakeholder: "Parents", count: 6, questions: ["Are children interested in culture? (Yes/No)","Do you encourage participation? (Yes/No)","Are programs available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are traditions declining? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are students interested? (Yes/No)","Are programs conducted? (Yes/No)","Are activities included? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Poor Documentation of Local History & Stories": [
+    { stakeholder: "Elders", count: 8, questions: ["Are stories documented? (Yes/No)","Do you share knowledge? (Yes/No)","Are records maintained? (Yes/No)","Are traditions written down? (Yes/No)","Are improvements needed? (Yes/No)","Are stories being lost? (Yes/No)","Are efforts made? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are you aware of local history? (Yes/No)","Do you collect stories? (Yes/No)","Are projects conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are stories interesting? (Yes/No)"] },
+    { stakeholder: "Researchers", count: 6, questions: ["Are studies conducted? (Yes/No)","Are records available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are efforts effective? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  "Neglect of Historical Sites & Monuments": [
+    { stakeholder: "Residents", count: 8, questions: ["Are heritage sites maintained? (Yes/No)","Are sites damaged? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you visit these sites? (Yes/No)","Are improvements needed? (Yes/No)","Are sites protected? (Yes/No)","Are problems increasing? (Yes/No)","Are actions taken? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are sites monitored? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are maintenance activities conducted? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Tourists", count: 6, questions: ["Are sites attractive? (Yes/No)","Are facilities available? (Yes/No)","Are sites clean? (Yes/No)","Are improvements needed? (Yes/No)","Are services adequate? (Yes/No)","Are experiences satisfactory? (Yes/No)"] }
+  ],
+  "Disappearance of Local Arts & Crafts": [
+    { stakeholder: "Artisans", count: 8, questions: ["Are traditional crafts declining? (Yes/No)","Are sales decreasing? (Yes/No)","Are youth interested? (Yes/No)","Are markets available? (Yes/No)","Are incomes sufficient? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are skills being transferred? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Are you interested in crafts? (Yes/No)","Are training programs available? (Yes/No)","Are opportunities sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are crafts relevant? (Yes/No)","Are skills declining? (Yes/No)"] },
+    { stakeholder: "Customers", count: 6, questions: ["Do you buy local crafts? (Yes/No)","Are products available? (Yes/No)","Are prices reasonable? (Yes/No)","Are improvements needed? (Yes/No)","Are options sufficient? (Yes/No)","Are products attractive? (Yes/No)"] }
+  ],
+  "Lack of Cultural Events & Community Participation": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you participate in cultural events? (Yes/No)","Are events conducted regularly? (Yes/No)","Are you encouraged to participate? (Yes/No)","Are programs engaging? (Yes/No)","Are improvements needed? (Yes/No)","Is participation low? (Yes/No)","Are traditions followed? (Yes/No)","Are people interested? (Yes/No)"] },
+    { stakeholder: "Community Leaders", count: 6, questions: ["Are events organized? (Yes/No)","Is participation high? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are programs effective? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Do you participate in events? (Yes/No)","Are programs interesting? (Yes/No)","Are opportunities available? (Yes/No)","Are improvements needed? (Yes/No)","Are traditions relevant? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Language & Dialect Decline": [
+    { stakeholder: "Elders", count: 8, questions: ["Are local languages declining? (Yes/No)","Do youth speak local dialects? (Yes/No)","Are traditions linked to language? (Yes/No)","Are efforts made to preserve language? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are languages taught? (Yes/No)","Are practices changing? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Do you speak local language? (Yes/No)","Do you prefer other languages? (Yes/No)","Are you taught local language? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are languages declining? (Yes/No)"] },
+    { stakeholder: "Teachers", count: 6, questions: ["Are local languages taught? (Yes/No)","Are students interested? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Lack of Awareness about Cultural Heritage": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of cultural heritage? (Yes/No)","Do you participate in activities? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are traditions followed? (Yes/No)","Are improvements needed? (Yes/No)","Is awareness low? (Yes/No)","Are habits changing? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are cultural topics taught? (Yes/No)","Do you participate in activities? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are programs effective? (Yes/No)","Are challenges present? (Yes/No)","Are improvements visible? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  "Commercialization Affecting Authentic Culture": [
+    { stakeholder: "Artisans", count: 8, questions: ["Are traditions commercialized? (Yes/No)","Are products losing authenticity? (Yes/No)","Are profits sufficient? (Yes/No)","Are markets available? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are traditions changing? (Yes/No)","Are practices sustainable? (Yes/No)"] },
+    { stakeholder: "Customers", count: 6, questions: ["Are products authentic? (Yes/No)","Do you prefer traditional items? (Yes/No)","Are prices reasonable? (Yes/No)","Are improvements needed? (Yes/No)","Are products attractive? (Yes/No)","Are options sufficient? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are policies implemented? (Yes/No)","Are artisans supported? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Intergenerational Knowledge Transfer": [
+    { stakeholder: "Elders", count: 8, questions: ["Do you teach traditions to youth? (Yes/No)","Are youth interested? (Yes/No)","Are practices shared regularly? (Yes/No)","Are traditions declining? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are efforts made? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Youth", count: 6, questions: ["Do elders teach traditions? (Yes/No)","Are you interested in learning? (Yes/No)","Are opportunities available? (Yes/No)","Are improvements needed? (Yes/No)","Are traditions relevant? (Yes/No)","Are practices declining? (Yes/No)"] },
+    { stakeholder: "Families", count: 6, questions: ["Are traditions followed at home? (Yes/No)","Do families encourage learning? (Yes/No)","Are practices shared? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are traditions declining? (Yes/No)"] }
+  ],
+  // DISASTER PREPAREDNESS & RESILIENCE
+  "Lack of Awareness about Disaster Risks": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of disaster risks in your area? (Yes/No)","Do you know types of disasters (flood, cyclone, etc.)? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you know safety measures? (Yes/No)","Are risks increasing? (Yes/No)","Are information sources available? (Yes/No)","Are improvements needed? (Yes/No)","Are people aware in your community? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are disaster topics taught? (Yes/No)","Are drills conducted? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you know safety measures? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Are communities informed? (Yes/No)","Are materials distributed? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Absence of Early Warning Systems": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you receive disaster warnings? (Yes/No)","Are warnings timely? (Yes/No)","Are warnings understandable? (Yes/No)","Do you trust warning systems? (Yes/No)","Are communication channels available? (Yes/No)","Are improvements needed? (Yes/No)","Do you take action after warnings? (Yes/No)","Are systems reliable? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are warning systems implemented? (Yes/No)","Are systems monitored? (Yes/No)","Are improvements planned? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)","Are resources sufficient? (Yes/No)"] },
+    { stakeholder: "Local Bodies", count: 6, questions: ["Are alerts communicated effectively? (Yes/No)","Are channels reliable? (Yes/No)","Are improvements needed? (Yes/No)","Are systems maintained? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Inadequate Emergency Preparedness at Household Level": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you have emergency kits? (Yes/No)","Do you have evacuation plans? (Yes/No)","Do you know safe locations? (Yes/No)","Are preparations sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Do you practice drills? (Yes/No)","Are risks understood? (Yes/No)","Are resources available? (Yes/No)"] },
+    { stakeholder: "Families", count: 6, questions: ["Are emergency plans prepared? (Yes/No)","Are children aware of safety steps? (Yes/No)","Are supplies maintained? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are practices followed? (Yes/No)"] },
+    { stakeholder: "Volunteers", count: 6, questions: ["Are households prepared? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are resources sufficient? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Poor Community-Level Disaster Planning": [
+    { stakeholder: "Residents", count: 8, questions: ["Are community plans available? (Yes/No)","Do you know evacuation routes? (Yes/No)","Are drills conducted? (Yes/No)","Are shelters available? (Yes/No)","Are improvements needed? (Yes/No)","Are risks identified? (Yes/No)","Are plans effective? (Yes/No)","Are people involved? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are plans developed? (Yes/No)","Are communities involved? (Yes/No)","Are drills conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are plans implemented? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Training in Disaster Response & First Aid": [
+    { stakeholder: "Residents", count: 8, questions: ["Have you received training? (Yes/No)","Do you know first aid? (Yes/No)","Are training programs conducted? (Yes/No)","Are skills sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are programs effective? (Yes/No)","Are risks understood? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are training programs conducted? (Yes/No)","Are communities trained? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Trainers", count: 6, questions: ["Are sessions conducted regularly? (Yes/No)","Are participants engaged? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Weak Infrastructure Resilience (roads, buildings, drainage)": [
+    { stakeholder: "Residents", count: 8, questions: ["Are buildings safe during disasters? (Yes/No)","Are roads accessible? (Yes/No)","Are drainage systems adequate? (Yes/No)","Are improvements needed? (Yes/No)","Are risks present? (Yes/No)","Are damages frequent? (Yes/No)","Are systems maintained? (Yes/No)","Are facilities reliable? (Yes/No)"] },
+    { stakeholder: "Engineers", count: 6, questions: ["Are structures disaster-resistant? (Yes/No)","Are standards followed? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)","Are monitoring systems active? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are infrastructure projects implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Poor Coordination among Authorities during Disasters": [
+    { stakeholder: "Officials", count: 8, questions: ["Are coordination systems available? (Yes/No)","Are roles clearly defined? (Yes/No)","Are communication systems effective? (Yes/No)","Are drills conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are responses timely? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Volunteers", count: 6, questions: ["Are you trained for coordination? (Yes/No)","Are roles clear? (Yes/No)","Are systems effective? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are responses effective? (Yes/No)"] },
+    { stakeholder: "Residents", count: 6, questions: ["Are authorities responsive? (Yes/No)","Are services timely? (Yes/No)","Are improvements needed? (Yes/No)","Are communication systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes satisfactory? (Yes/No)"] }
+  ],
+  "Lack of Access to Emergency Resources (shelters, kits)": [
+    { stakeholder: "Residents", count: 8, questions: ["Are shelters available? (Yes/No)","Are emergency kits accessible? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are services accessible? (Yes/No)","Are facilities adequate? (Yes/No)","Are systems reliable? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are resources provided? (Yes/No)","Are systems implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are monitoring systems active? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are support programs conducted? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Is participation high? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "Vulnerability of High-Risk Groups (elderly, children, disabled)": [
+    { stakeholder: "Elderly/Disabled", count: 6, questions: ["Do you receive support during disasters? (Yes/No)","Are facilities accessible? (Yes/No)","Are needs addressed? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are services available? (Yes/No)"] },
+    { stakeholder: "Families", count: 6, questions: ["Are vulnerable members supported? (Yes/No)","Are plans prepared? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are special programs implemented? (Yes/No)","Are vulnerable groups identified? (Yes/No)","Are services accessible? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Post-Disaster Recovery & Rehabilitation Gaps": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you receive support after disasters? (Yes/No)","Are recovery services timely? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are livelihoods restored? (Yes/No)","Are damages repaired? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are recovery programs implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are support programs conducted? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Is participation high? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  // RENEWABLE ENERGY & SUSTAINABILITY
+  "Low Awareness about Renewable Energy": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of renewable energy sources? (Yes/No)","Do you know benefits of solar energy? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you understand energy-saving methods? (Yes/No)","Are information sources available? (Yes/No)","Are people aware in your area? (Yes/No)","Are improvements needed? (Yes/No)","Are renewable options discussed locally? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are renewable topics taught? (Yes/No)","Are awareness programs conducted? (Yes/No)","Do you understand sustainability? (Yes/No)","Are projects conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Are communities informed? (Yes/No)","Are schemes promoted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Limited Adoption of Solar Energy Systems": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you use solar energy? (Yes/No)","Are systems affordable? (Yes/No)","Are installations available locally? (Yes/No)","Are benefits known? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are systems reliable? (Yes/No)","Are subsidies known? (Yes/No)"] },
+    { stakeholder: "Technicians", count: 6, questions: ["Are installations increasing? (Yes/No)","Are systems maintained properly? (Yes/No)","Are challenges present? (Yes/No)","Are skills sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are solar programs implemented? (Yes/No)","Are subsidies provided? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "High Dependence on Non-Renewable Energy Sources": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you depend on electricity from fossil fuels? (Yes/No)","Are renewable alternatives used? (Yes/No)","Are costs high? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are options available? (Yes/No)","Are habits changing? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Businesses", count: 6, questions: ["Do you use renewable energy? (Yes/No)","Are energy costs high? (Yes/No)","Are alternatives available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems efficient? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are renewable policies implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Government Scheme Awareness (subsidies, solar programs)": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you know about renewable energy schemes? (Yes/No)","Are subsidies known? (Yes/No)","Are application processes easy? (Yes/No)","Are benefits understood? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are programs accessible? (Yes/No)","Are opportunities sufficient? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are schemes implemented? (Yes/No)","Are beneficiaries covered? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Banks", count: 6, questions: ["Are loans provided for renewable systems? (Yes/No)","Are processes simple? (Yes/No)","Are applicants supported? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  "High Initial Cost of Renewable Energy Installation": [
+    { stakeholder: "Residents", count: 8, questions: ["Are installation costs high? (Yes/No)","Are you able to afford systems? (Yes/No)","Are financial supports available? (Yes/No)","Are loans accessible? (Yes/No)","Are improvements needed? (Yes/No)","Are benefits worth cost? (Yes/No)","Are challenges present? (Yes/No)","Are alternatives available? (Yes/No)"] },
+    { stakeholder: "Vendors", count: 6, questions: ["Are costs a barrier? (Yes/No)","Are customers interested? (Yes/No)","Are subsidies effective? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems affordable? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are subsidies sufficient? (Yes/No)","Are financial schemes implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Poor Maintenance of Installed Renewable Systems": [
+    { stakeholder: "Users", count: 8, questions: ["Are systems maintained regularly? (Yes/No)","Do you face technical issues? (Yes/No)","Are services available? (Yes/No)","Are repairs affordable? (Yes/No)","Are improvements needed? (Yes/No)","Are systems reliable? (Yes/No)","Are challenges present? (Yes/No)","Are service providers accessible? (Yes/No)"] },
+    { stakeholder: "Technicians", count: 6, questions: ["Are maintenance services available? (Yes/No)","Are challenges present? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are systems reliable? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are maintenance programs supported? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are monitoring systems active? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Energy Conservation Practices": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you save electricity? (Yes/No)","Do you use energy-efficient appliances? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are habits changing? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are resources available? (Yes/No)","Are practices effective? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are conservation practices taught? (Yes/No)","Do you follow them? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are awareness levels high? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are campaigns conducted? (Yes/No)","Are programs effective? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Limited Access to Clean Cooking Energy (LPG/biogas)": [
+    { stakeholder: "Households", count: 8, questions: ["Do you use LPG/clean fuel? (Yes/No)","Are alternatives available? (Yes/No)","Are costs affordable? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are health issues present? (Yes/No)","Are challenges present? (Yes/No)","Are options sufficient? (Yes/No)"] },
+    { stakeholder: "Women", count: 6, questions: ["Do you use clean cooking methods? (Yes/No)","Are traditional fuels used? (Yes/No)","Are health issues present? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are programs implemented? (Yes/No)","Are subsidies provided? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Low Community Participation in Sustainability Practices": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you participate in sustainability activities? (Yes/No)","Are programs conducted? (Yes/No)","Are habits eco-friendly? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are resources available? (Yes/No)","Are practices effective? (Yes/No)","Are participation levels high? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are sustainability programs conducted? (Yes/No)","Is participation high? (Yes/No)","Are resources sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are initiatives implemented? (Yes/No)","Are communities engaged? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Institutional Support for Renewable Energy Initiatives": [
+    { stakeholder: "Institutions", count: 6, questions: ["Are renewable initiatives supported? (Yes/No)","Are programs conducted? (Yes/No)","Are resources available? (Yes/No)","Are improvements needed? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are policies implemented? (Yes/No)","Are funds sufficient? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Entrepreneurs", count: 6, questions: ["Are support systems available? (Yes/No)","Are incentives provided? (Yes/No)","Are opportunities sufficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes effective? (Yes/No)"] }
+  ],
+  // ENERGY UTILIZATION & EFFICIENCY
+  "High Electricity Consumption in Households": [
+    { stakeholder: "Households", count: 8, questions: ["Do you have high electricity bills? (Yes/No)","Do you use appliances frequently? (Yes/No)","Are energy-saving methods followed? (Yes/No)","Are efficient appliances used? (Yes/No)","Are lights/fans left on unnecessarily? (Yes/No)","Are improvements needed? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are bills increasing? (Yes/No)"] },
+    { stakeholder: "Electricity Staff", count: 6, questions: ["Are consumption levels high? (Yes/No)","Are households aware of efficiency? (Yes/No)","Are monitoring systems active? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are programs conducted? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are energy-saving programs implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are awareness campaigns conducted? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Low Awareness of Energy Efficiency Practices": [
+    { stakeholder: "Residents", count: 8, questions: ["Are you aware of energy-saving methods? (Yes/No)","Do you practice energy efficiency? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are habits changing? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are benefits known? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Are energy topics taught? (Yes/No)","Do you follow energy-saving practices? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are knowledge levels high? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are campaigns conducted? (Yes/No)","Are programs effective? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Use of Inefficient Appliances": [
+    { stakeholder: "Households", count: 8, questions: ["Do you use old appliances? (Yes/No)","Are appliances energy-efficient? (Yes/No)","Do you check energy ratings? (Yes/No)","Are costs a barrier to efficient devices? (Yes/No)","Are improvements needed? (Yes/No)","Are alternatives available? (Yes/No)","Are bills affected by appliances? (Yes/No)","Are habits changing? (Yes/No)"] },
+    { stakeholder: "Vendors", count: 6, questions: ["Are efficient appliances available? (Yes/No)","Are customers aware of ratings? (Yes/No)","Are sales of efficient devices high? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are costs affordable? (Yes/No)"] },
+    { stakeholder: "Technicians", count: 6, questions: ["Are inefficient appliances common? (Yes/No)","Are repair services available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Poor Energy Management in Public Buildings": [
+    { stakeholder: "Staff", count: 8, questions: ["Are lights/fans left on unnecessarily? (Yes/No)","Are energy-saving practices followed? (Yes/No)","Are systems monitored? (Yes/No)","Are improvements needed? (Yes/No)","Are devices efficient? (Yes/No)","Are habits responsible? (Yes/No)","Are challenges present? (Yes/No)","Are policies followed? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are energy policies implemented? (Yes/No)","Are monitoring systems active? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Visitors", count: 6, questions: ["Do you observe wastage? (Yes/No)","Are facilities efficient? (Yes/No)","Are improvements needed? (Yes/No)","Are systems reliable? (Yes/No)","Are services satisfactory? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Lack of Monitoring of Energy Usage": [
+    { stakeholder: "Households", count: 8, questions: ["Do you track electricity usage? (Yes/No)","Do you monitor bills regularly? (Yes/No)","Are smart meters available? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are habits changing? (Yes/No)","Are costs increasing? (Yes/No)","Are systems reliable? (Yes/No)"] },
+    { stakeholder: "Staff", count: 6, questions: ["Are usage records maintained? (Yes/No)","Are systems monitored? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are monitoring systems implemented? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)","Are resources sufficient? (Yes/No)"] }
+  ],
+  "Inefficient Agricultural Energy Use (pumps, motors)": [
+    { stakeholder: "Farmers", count: 8, questions: ["Do you use electric pumps? (Yes/No)","Are pumps energy-efficient? (Yes/No)","Are costs high? (Yes/No)","Are maintenance issues present? (Yes/No)","Are improvements needed? (Yes/No)","Are alternatives available? (Yes/No)","Are subsidies known? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Technicians", count: 6, questions: ["Are systems efficient? (Yes/No)","Are maintenance services available? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are agricultural energy programs implemented? (Yes/No)","Are subsidies provided? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "High Energy Wastage in Commercial Establishments": [
+    { stakeholder: "Shop Owners", count: 8, questions: ["Do you use energy-efficient lighting? (Yes/No)","Are appliances efficient? (Yes/No)","Are lights left on unnecessarily? (Yes/No)","Are costs high? (Yes/No)","Are improvements needed? (Yes/No)","Are alternatives available? (Yes/No)","Are savings considered? (Yes/No)","Are habits responsible? (Yes/No)"] },
+    { stakeholder: "Employees", count: 6, questions: ["Are energy-saving practices followed? (Yes/No)","Are systems efficient? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are habits responsible? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Customers", count: 6, questions: ["Do you observe wastage? (Yes/No)","Are shops efficient? (Yes/No)","Are improvements needed? (Yes/No)","Are services satisfactory? (Yes/No)","Are facilities efficient? (Yes/No)","Are challenges present? (Yes/No)"] }
+  ],
+  "Limited Adoption of Energy-Efficient Technologies (LEDs, star-rated devices)": [
+    { stakeholder: "Households", count: 8, questions: ["Do you use LED lights? (Yes/No)","Do you use star-rated appliances? (Yes/No)","Are costs affordable? (Yes/No)","Are benefits known? (Yes/No)","Are improvements needed? (Yes/No)","Are alternatives available? (Yes/No)","Are habits changing? (Yes/No)","Are challenges present? (Yes/No)"] },
+    { stakeholder: "Vendors", count: 6, questions: ["Are efficient products available? (Yes/No)","Are customers aware? (Yes/No)","Are sales increasing? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are prices affordable? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are programs implemented? (Yes/No)","Are incentives provided? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Behavioral Change towards Energy Saving": [
+    { stakeholder: "Residents", count: 8, questions: ["Do you switch off unused appliances? (Yes/No)","Do you follow energy-saving habits? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are habits improving? (Yes/No)","Are improvements needed? (Yes/No)","Are challenges present? (Yes/No)","Are practices effective? (Yes/No)","Are behaviors consistent? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Do you follow energy-saving practices? (Yes/No)","Are habits taught? (Yes/No)","Are programs conducted? (Yes/No)","Are improvements needed? (Yes/No)","Are awareness levels high? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Leaders", count: 6, questions: ["Are campaigns conducted? (Yes/No)","Are communities engaged? (Yes/No)","Are improvements planned? (Yes/No)","Are systems effective? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  "Lack of Institutional Policies for Energy Efficiency": [
+    { stakeholder: "Institutions", count: 6, questions: ["Are energy policies implemented? (Yes/No)","Are systems monitored? (Yes/No)","Are improvements needed? (Yes/No)","Are resources available? (Yes/No)","Are policies followed? (Yes/No)","Are outcomes effective? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are policies enforced? (Yes/No)","Are improvements planned? (Yes/No)","Are monitoring systems active? (Yes/No)","Are challenges present? (Yes/No)","Are systems effective? (Yes/No)","Are outcomes visible? (Yes/No)"] },
+    { stakeholder: "Staff", count: 6, questions: ["Are policies followed? (Yes/No)","Are systems efficient? (Yes/No)","Are improvements needed? (Yes/No)","Are habits responsible? (Yes/No)","Are challenges present? (Yes/No)","Are outcomes visible? (Yes/No)"] }
+  ],
+  // WATER CONSERVATION
+  "Groundwater Depletion due to Over-Extraction": [
+    { stakeholder: "Farmers", count: 9, questions: ["Do you depend mainly on borewell water? (Yes/No)","Has groundwater level decreased over years? (Yes/No)","Have borewells dried up? (Yes/No)","Have you drilled multiple borewells? (Yes/No)","Have you increased borewell depth? (Yes/No)","Do you face water shortage for crops? (Yes/No)","Do nearby farmers face the same issue? (Yes/No)","Do you follow recharge practices? (Yes/No)","Do you think groundwater will reduce further? (Yes/No)"] },
+    { stakeholder: "Households", count: 8, questions: ["Is your main water source borewell? (Yes/No)","Do you face summer water shortage? (Yes/No)","Has water availability reduced? (Yes/No)","Do you depend on tanker water? (Yes/No)","Do you store water regularly? (Yes/No)","Do you feel groundwater is declining? (Yes/No)","Do you use water carefully? (Yes/No)","Are you aware of conservation methods? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 7, questions: ["Are borewells increasing in the village? (Yes/No)","Is groundwater monitored? (Yes/No)","Are recharge systems available? (Yes/No)","Are restrictions on borewell drilling present? (Yes/No)","Are awareness programs conducted? (Yes/No)","Is depletion worsening? (Yes/No)","Are future plans available? (Yes/No)"] }
+  ],
+  "Inefficient Agricultural Water Usage": [
+    { stakeholder: "Farmers", count: 9, questions: ["Do you use flood irrigation? (Yes/No)","Do you over-irrigate fields? (Yes/No)","Do you grow water-intensive crops? (Yes/No)","Are you aware of drip irrigation? (Yes/No)","Have you adopted efficient irrigation? (Yes/No)","Do you think modern systems are costly? (Yes/No)","Have you faced water shortage due to misuse? (Yes/No)","Do you follow irrigation schedules? (Yes/No)","Are you willing to change practices? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Are farmers trained on efficient irrigation? (Yes/No)","Are subsidies available? (Yes/No)","Is adoption low? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are demonstration farms available? (Yes/No)","Is water wastage high? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Is irrigation monitored locally? (Yes/No)","Are farmers supported? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are funds allocated? (Yes/No)","Are improvements planned? (Yes/No)","Is water misuse common? (Yes/No)"] }
+  ],
+  "Lack of Rainwater Harvesting Systems": [
+    { stakeholder: "Households", count: 8, questions: ["Does rainwater go to waste? (Yes/No)","Do you have harvesting system? (Yes/No)","Are you aware of its benefits? (Yes/No)","Do you think it is costly? (Yes/No)","Do you know how to install it? (Yes/No)","Are you willing to adopt it? (Yes/No)","Do you face water shortage despite rainfall? (Yes/No)","Do you think rainwater can be reused? (Yes/No)"] },
+    { stakeholder: "Institutions", count: 6, questions: ["Is rainwater harvesting implemented? (Yes/No)","Is rooftop water utilized? (Yes/No)","Are systems maintained? (Yes/No)","Do you face water shortage? (Yes/No)","Are people aware? (Yes/No)","Are future plans available? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 7, questions: ["Are systems promoted? (Yes/No)","Are schemes implemented? (Yes/No)","Are public buildings equipped? (Yes/No)","Are systems functional? (Yes/No)","Is awareness high? (Yes/No)","Are incentives provided? (Yes/No)","Is monitoring done? (Yes/No)"] }
+  ],
+  "Water Pollution & Contamination": [
+    { stakeholder: "Households", count: 8, questions: ["Do you treat water before drinking? (Yes/No)","Do you notice bad smell/taste? (Yes/No)","Is water source near drainage? (Yes/No)","Have you tested water? (Yes/No)","Do you face health issues? (Yes/No)","Do you use filters/boiling? (Yes/No)","Do you trust water safety? (Yes/No)","Do you depend on a single source? (Yes/No)"] },
+    { stakeholder: "Farmers", count: 7, questions: ["Do you use chemicals heavily? (Yes/No)","Do chemicals reach water bodies? (Yes/No)","Do you dispose waste near water? (Yes/No)","Do you think farming affects water quality? (Yes/No)","Do you use organic methods? (Yes/No)","Is runoff common? (Yes/No)","Are you aware of pollution impact? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are water-borne diseases common? (Yes/No)","Is unsafe water a major cause? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are water tests conducted? (Yes/No)","Are children more affected? (Yes/No)","Is improvement seen? (Yes/No)"] }
+  ],
+  "Decline of Traditional Water Bodies": [
+    { stakeholder: "Elders", count: 7, questions: ["Were ponds more abundant earlier? (Yes/No)","Are they now dry? (Yes/No)","Were they used regularly? (Yes/No)","Have they been encroached? (Yes/No)","Has condition worsened? (Yes/No)","Were they used for irrigation? (Yes/No)","Do people depend less now? (Yes/No)"] },
+    { stakeholder: "Farmers", count: 6, questions: ["Did you depend on ponds earlier? (Yes/No)","Do you use them now? (Yes/No)","Have you shifted to borewells? (Yes/No)","Are ponds useful now? (Yes/No)","Do they recharge groundwater? (Yes/No)","Do you support revival? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 7, questions: ["Are water bodies maintained? (Yes/No)","Are desilting works done? (Yes/No)","Are encroachments present? (Yes/No)","Are funds allocated? (Yes/No)","Are revival efforts ongoing? (Yes/No)","Is community involved? (Yes/No)","Is monitoring done? (Yes/No)"] }
+  ],
+  "Climate Variability & Irregular Rainfall": [
+    { stakeholder: "Farmers", count: 7, questions: ["Is rainfall irregular? (Yes/No)","Are dry spells increasing? (Yes/No)","Is crop yield affected? (Yes/No)","Have crop patterns changed? (Yes/No)","Do you face drought? (Yes/No)","Is water unpredictable? (Yes/No)","Are losses increasing? (Yes/No)"] },
+    { stakeholder: "Elders", count: 6, questions: ["Was rainfall predictable earlier? (Yes/No)","Has climate changed? (Yes/No)","Are droughts frequent? (Yes/No)","Has water reduced? (Yes/No)","Are seasons shifting? (Yes/No)","Is change noticeable? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is climate impact increasing? (Yes/No)","Are farmers trained? (Yes/No)","Are advisories issued? (Yes/No)","Are mitigation plans present? (Yes/No)","Is monitoring done? (Yes/No)","Are programs effective? (Yes/No)"] }
+  ],
+  "Water Mismanagement & Leakage": [
+    { stakeholder: "Households", count: 8, questions: ["Do you notice leakage at home? (Yes/No)","Do you see public pipeline leakage? (Yes/No)","Do you report issues? (Yes/No)","Is water supply irregular? (Yes/No)","Do you store water? (Yes/No)","Do you waste water unintentionally? (Yes/No)","Do you reuse water? (Yes/No)","Do you think water is wasted locally? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are pipelines inspected regularly? (Yes/No)","Are complaints resolved quickly? (Yes/No)","Is water loss high? (Yes/No)","Are funds sufficient? (Yes/No)","Are systems monitored? (Yes/No)","Are improvements planned? (Yes/No)"] },
+    { stakeholder: "Workers", count: 6, questions: ["Are leakages frequent? (Yes/No)","Is maintenance regular? (Yes/No)","Are tools sufficient? (Yes/No)","Is workload manageable? (Yes/No)","Are repairs delayed? (Yes/No)","Is infrastructure old? (Yes/No)"] }
+  ],
+  "Lack of Community Awareness on Water Conservation": [
+    { stakeholder: "Households", count: 7, questions: ["Do you turn off taps properly? (Yes/No)","Do you reuse water? (Yes/No)","Do you believe water scarcity is serious? (Yes/No)","Do you educate children? (Yes/No)","Do you monitor usage? (Yes/No)","Do you attend awareness programs? (Yes/No)","Do you think saving water is important? (Yes/No)"] },
+    { stakeholder: "Students", count: 6, questions: ["Have you learned about water conservation? (Yes/No)","Do you practice saving water? (Yes/No)","Do you spread awareness? (Yes/No)","Do schools conduct programs? (Yes/No)","Do you participate in campaigns? (Yes/No)","Are you interested in solving water issues? (Yes/No)"] },
+    { stakeholder: "NGOs", count: 6, questions: ["Are awareness programs conducted? (Yes/No)","Is participation high? (Yes/No)","Is awareness low? (Yes/No)","Are campaigns effective? (Yes/No)","Are materials distributed? (Yes/No)","Is improvement visible? (Yes/No)"] }
+  ],
+  "Weak Water Governance & Regulation": [
+    { stakeholder: "Panchayat", count: 8, questions: ["Is there a water management plan? (Yes/No)","Are groundwater records maintained? (Yes/No)","Are rules enforced? (Yes/No)","Is there a water committee? (Yes/No)","Are funds used properly? (Yes/No)","Are meetings conducted? (Yes/No)","Is data recorded? (Yes/No)","Is community involved? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are policies implemented? (Yes/No)","Is monitoring effective? (Yes/No)","Are violations penalized? (Yes/No)","Are programs active? (Yes/No)","Are systems digitized? (Yes/No)","Are improvements visible? (Yes/No)"] },
+    { stakeholder: "Community Leaders", count: 6, questions: ["Are people aware of rules? (Yes/No)","Is community participation high? (Yes/No)","Are conflicts present? (Yes/No)","Are decisions transparent? (Yes/No)","Are issues reported? (Yes/No)","Are solutions discussed? (Yes/No)"] }
+  ],
+  "Demand-Supply Gap in Water Resources": [
+    { stakeholder: "Households", count: 8, questions: ["Do you receive water daily? (Yes/No)","Is supply sufficient? (Yes/No)","Do you store water? (Yes/No)","Do you depend on tankers? (Yes/No)","Has supply reduced? (Yes/No)","Do you face summer shortage? (Yes/No)","Do you adjust usage? (Yes/No)","Do you pay extra for water? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 7, questions: ["Does demand exceed supply? (Yes/No)","Are shortages seasonal? (Yes/No)","Are alternative sources available? (Yes/No)","Are tankers used? (Yes/No)","Is supply monitored? (Yes/No)","Are expansion plans available? (Yes/No)","Is data recorded? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is demand increasing? (Yes/No)","Are supply systems sufficient? (Yes/No)","Are projects ongoing? (Yes/No)","Is planning effective? (Yes/No)","Are shortages predicted? (Yes/No)","Are improvements planned? (Yes/No)"] }
+  ],
+  // AGRICULTURE
+  "Water Scarcity for Irrigation": [
+    { stakeholder: "Farmers", count: 9, questions: ["Do you depend on borewell water? (Yes/No)","Do you face water shortage during crop season? (Yes/No)","Has water availability reduced? (Yes/No)","Do crops fail due to water shortage? (Yes/No)","Do you use efficient irrigation methods? (Yes/No)","Have borewells failed? (Yes/No)","Do you depend on rainfall? (Yes/No)","Do others face the same issue? (Yes/No)","Are you aware of conservation methods? (Yes/No)"] },
+    { stakeholder: "Water Officials", count: 6, questions: ["Is irrigation supply sufficient? (Yes/No)","Is groundwater declining? (Yes/No)","Are farmers trained? (Yes/No)","Are schemes effective? (Yes/No)","Are resources monitored? (Yes/No)","Are alternatives planned? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Are irrigation systems available? (Yes/No)","Are water bodies maintained? (Yes/No)","Are farmers supported? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are funds available? (Yes/No)","Are improvements planned? (Yes/No)"] }
+  ],
+  "Overuse of Chemical Fertilizers & Pesticides": [
+    { stakeholder: "Farmers", count: 8, questions: ["Do you use fertilizers regularly? (Yes/No)","Do you use pesticides frequently? (Yes/No)","Has usage increased? (Yes/No)","Do you follow dosage guidelines? (Yes/No)","Do you face soil issues? (Yes/No)","Are you aware of organic farming? (Yes/No)","Have you tried organic methods? (Yes/No)","Are input costs high? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Are farmers trained? (Yes/No)","Is misuse common? (Yes/No)","Are soil tests conducted? (Yes/No)","Are organic methods promoted? (Yes/No)","Are regulations enforced? (Yes/No)","Are awareness programs effective? (Yes/No)"] },
+    { stakeholder: "Consumers", count: 6, questions: ["Do you prefer organic food? (Yes/No)","Are you aware of pesticide risks? (Yes/No)","Do you trust local produce? (Yes/No)","Are prices a concern? (Yes/No)","Do you check quality? (Yes/No)","Do you think food safety is an issue? (Yes/No)"] }
+  ],
+  "Lack of Awareness on Sustainable Farming": [
+    { stakeholder: "Farmers", count: 7, questions: ["Are you aware of sustainable practices? (Yes/No)","Do you practice crop rotation? (Yes/No)","Do you use organic inputs? (Yes/No)","Are you willing to adopt new methods? (Yes/No)","Have you received training? (Yes/No)","Are such practices common locally? (Yes/No)","Do you see benefits? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Are trainings conducted? (Yes/No)","Are farmers participating? (Yes/No)","Are sustainable methods promoted? (Yes/No)","Are demo farms available? (Yes/No)","Are subsidies available? (Yes/No)","Is adoption increasing? (Yes/No)"] },
+    { stakeholder: "NGOs/Experts", count: 6, questions: ["Are awareness programs active? (Yes/No)","Is adoption low? (Yes/No)","Are challenges faced? (Yes/No)","Are farmers interested? (Yes/No)","Are field demonstrations effective? (Yes/No)","Are results visible? (Yes/No)"] }
+  ],
+  "Soil Degradation & Loss of Fertility": [
+    { stakeholder: "Farmers", count: 8, questions: ["Has soil fertility reduced? (Yes/No)","Do you test soil regularly? (Yes/No)","Is yield decreasing? (Yes/No)","Do you use organic manure? (Yes/No)","Is soil erosion present? (Yes/No)","Do you use heavy chemicals? (Yes/No)","Are you aware of soil health cards? (Yes/No)","Do you follow conservation practices? (Yes/No)"] },
+    { stakeholder: "Soil Experts", count: 6, questions: ["Is soil degradation increasing? (Yes/No)","Are tests conducted regularly? (Yes/No)","Are farmers aware? (Yes/No)","Are conservation programs effective? (Yes/No)","Are results improving? (Yes/No)","Are recommendations followed? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Are soil programs implemented? (Yes/No)","Are farmers trained? (Yes/No)","Are soil cards distributed? (Yes/No)","Are funds allocated? (Yes/No)","Is monitoring done? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Lack of Access to Modern Agricultural Technology": [
+    { stakeholder: "Farmers", count: 8, questions: ["Do you use modern machinery? (Yes/No)","Is technology affordable? (Yes/No)","Do you access machinery easily? (Yes/No)","Do you use mobile apps? (Yes/No)","Are you aware of new techniques? (Yes/No)","Do you face difficulty adopting tech? (Yes/No)","Have you received training? (Yes/No)","Does technology improve yield? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Are tools promoted? (Yes/No)","Are subsidies available? (Yes/No)","Are trainings conducted? (Yes/No)","Is adoption low? (Yes/No)","Are demos conducted? (Yes/No)","Are programs effective? (Yes/No)"] },
+    { stakeholder: "Equipment Vendors", count: 6, questions: ["Is demand for machinery increasing? (Yes/No)","Do farmers find machines expensive? (Yes/No)","Are rental services available? (Yes/No)","Are farmers aware of products? (Yes/No)","Is usage seasonal? (Yes/No)","Are maintenance issues common? (Yes/No)"] }
+  ],
+  "Crop Losses Due to Climate Variability": [
+    { stakeholder: "Farmers", count: 8, questions: ["Is rainfall irregular? (Yes/No)","Are droughts increasing? (Yes/No)","Are crops failing due to weather? (Yes/No)","Have crop patterns changed? (Yes/No)","Are extreme events increasing? (Yes/No)","Is water unpredictable? (Yes/No)","Are losses increasing? (Yes/No)","Do you use adaptive methods? (Yes/No)"] },
+    { stakeholder: "Elders", count: 6, questions: ["Was rainfall stable earlier? (Yes/No)","Has climate changed? (Yes/No)","Are droughts more frequent? (Yes/No)","Has farming become harder? (Yes/No)","Are seasons shifting? (Yes/No)","Is water decreasing? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Are climate impacts increasing? (Yes/No)","Are farmers trained? (Yes/No)","Are advisories issued? (Yes/No)","Are schemes available? (Yes/No)","Is monitoring done? (Yes/No)","Are mitigation plans active? (Yes/No)"] }
+  ],
+  "Poor Market Access & Price Fluctuations": [
+    { stakeholder: "Farmers", count: 8, questions: ["Do you get fair prices? (Yes/No)","Do you depend on middlemen? (Yes/No)","Are prices unstable? (Yes/No)","Is market access easy? (Yes/No)","Do transport issues affect sales? (Yes/No)","Are you aware of digital markets? (Yes/No)","Do you store before selling? (Yes/No)","Do you face losses? (Yes/No)"] },
+    { stakeholder: "Traders", count: 6, questions: ["Are prices volatile? (Yes/No)","Do farmers depend on you? (Yes/No)","Is supply consistent? (Yes/No)","Are storage facilities adequate? (Yes/No)","Do farmers negotiate? (Yes/No)","Are digital systems used? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are markets accessible? (Yes/No)","Are MSP schemes implemented? (Yes/No)","Are farmers aware of pricing? (Yes/No)","Are digital platforms promoted? (Yes/No)","Are grievances addressed? (Yes/No)","Are improvements planned? (Yes/No)"] }
+  ],
+  "Lack of Storage & Post-Harvest Facilities": [
+    { stakeholder: "Farmers", count: 8, questions: ["Do you have storage facilities? (Yes/No)","Do crops spoil after harvest? (Yes/No)","Do you sell immediately? (Yes/No)","Are warehouses available nearby? (Yes/No)","Is storage affordable? (Yes/No)","Do pests damage crops? (Yes/No)","Are storage techniques known? (Yes/No)","Do losses occur frequently? (Yes/No)"] },
+    { stakeholder: "Warehouse Managers", count: 6, questions: ["Are facilities sufficient? (Yes/No)","Is capacity adequate? (Yes/No)","Are farmers using facilities? (Yes/No)","Are losses minimized? (Yes/No)","Is maintenance regular? (Yes/No)","Are charges affordable? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are warehouses available in all areas? (Yes/No)","Are schemes implemented? (Yes/No)","Are farmers supported? (Yes/No)","Are losses monitored? (Yes/No)","Are new facilities planned? (Yes/No)","Are funds allocated? (Yes/No)"] }
+  ],
+  "Farmer Debt & Financial Stress": [
+    { stakeholder: "Farmers", count: 8, questions: ["Have you taken loans? (Yes/No)","Is repayment difficult? (Yes/No)","Are crop failures increasing debt? (Yes/No)","Do you depend on private lenders? (Yes/No)","Are interest rates high? (Yes/No)","Do you receive government support? (Yes/No)","Do you feel financial stress? (Yes/No)","Are schemes helpful? (Yes/No)"] },
+    { stakeholder: "Banks", count: 6, questions: ["Are farmers taking loans frequently? (Yes/No)","Are defaults increasing? (Yes/No)","Are schemes available? (Yes/No)","Is awareness low? (Yes/No)","Are loans accessible? (Yes/No)","Is support adequate? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Are loan schemes implemented? (Yes/No)","Are subsidies provided? (Yes/No)","Are farmers aware? (Yes/No)","Are stress cases increasing? (Yes/No)","Are interventions planned? (Yes/No)","Is monitoring done? (Yes/No)"] }
+  ],
+  "Low Crop Productivity": [
+    { stakeholder: "Farmers", count: 8, questions: ["Has yield decreased? (Yes/No)","Do pests affect crops? (Yes/No)","Do you use quality seeds? (Yes/No)","Are practices outdated? (Yes/No)","Do you receive training? (Yes/No)","Is soil quality poor? (Yes/No)","Are inputs costly? (Yes/No)","Do you face water issues? (Yes/No)"] },
+    { stakeholder: "Agriculture Officers", count: 6, questions: ["Is productivity low? (Yes/No)","Are farmers trained? (Yes/No)","Are improved seeds provided? (Yes/No)","Are schemes effective? (Yes/No)","Is monitoring done? (Yes/No)","Are improvements visible? (Yes/No)"] },
+    { stakeholder: "Experts", count: 6, questions: ["Are modern practices adopted? (Yes/No)","Is awareness low? (Yes/No)","Are inputs adequate? (Yes/No)","Are training programs effective? (Yes/No)","Is yield improving? (Yes/No)","Are gaps identified? (Yes/No)"] }
+  ],
+  // VILLAGE INFRASTRUCTURE
+  "Poor Road Connectivity & Maintenance": [
+    { stakeholder: "Households", count: 8, questions: ["Are roads in your area in poor condition? (Yes/No)","Do roads become unusable during rainy season? (Yes/No)","Do you face difficulty reaching hospitals/schools? (Yes/No)","Has road condition worsened over time? (Yes/No)","Do accidents occur due to bad roads? (Yes/No)","Do you think roads affect your daily life? (Yes/No)","Have complaints been raised? (Yes/No)","Are repairs done regularly? (Yes/No)"] },
+    { stakeholder: "Drivers/Farmers", count: 7, questions: ["Do bad roads damage vehicles? (Yes/No)","Does transportation time increase due to roads? (Yes/No)","Do you avoid certain routes due to road condition? (Yes/No)","Does it affect crop transport? (Yes/No)","Do you incur extra costs due to road issues? (Yes/No)","Are roads properly connected to markets? (Yes/No)","Are roads safe for travel at night? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 7, questions: ["Are roads inspected regularly? (Yes/No)","Is there a budget for road maintenance? (Yes/No)","Are complaints addressed quickly? (Yes/No)","Are all areas connected by roads? (Yes/No)","Are roads constructed with proper quality? (Yes/No)","Are repair works delayed? (Yes/No)","Is there government support for road development? (Yes/No)"] }
+  ],
+  "Inadequate Drainage Systems": [
+    { stakeholder: "Households", count: 8, questions: ["Do you experience water stagnation near your home? (Yes/No)","Are drains clogged frequently? (Yes/No)","Do drains overflow during rains? (Yes/No)","Is foul smell common? (Yes/No)","Do mosquitoes increase due to drainage issues? (Yes/No)","Do you face health problems due to stagnation? (Yes/No)","Are drains covered properly? (Yes/No)","Are drainage systems cleaned regularly? (Yes/No)"] },
+    { stakeholder: "Sanitation Workers", count: 6, questions: ["Are drains cleaned regularly? (Yes/No)","Is manpower sufficient? (Yes/No)","Do people dump waste into drains? (Yes/No)","Are tools/equipment adequate? (Yes/No)","Are blockages frequent? (Yes/No)","Is maintenance planned or reactive? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 7, questions: ["Is there a proper drainage system in all areas? (Yes/No)","Are funds allocated for maintenance? (Yes/No)","Are complaints resolved quickly? (Yes/No)","Are drainage designs sufficient for heavy rains? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are inspections conducted regularly? (Yes/No)","Are improvements planned? (Yes/No)"] }
+  ],
+  "Irregular Electricity Supply": [
+    { stakeholder: "Households", count: 8, questions: ["Do you face frequent power cuts? (Yes/No)","Is voltage fluctuation common? (Yes/No)","Does power shortage affect daily life? (Yes/No)","Do you use backup power sources? (Yes/No)","Are outages longer in summer? (Yes/No)","Do you report electricity issues? (Yes/No)","Are issues resolved quickly? (Yes/No)","Do you feel supply is insufficient? (Yes/No)"] },
+    { stakeholder: "Businesses", count: 6, questions: ["Does power outage affect your business? (Yes/No)","Do you incur losses due to power cuts? (Yes/No)","Do you use generators? (Yes/No)","Is electricity reliable for operations? (Yes/No)","Are costs increasing due to backup systems? (Yes/No)","Do outages affect productivity? (Yes/No)"] },
+    { stakeholder: "Officials", count: 6, questions: ["Is supply meeting demand? (Yes/No)","Are complaints frequent? (Yes/No)","Is infrastructure outdated? (Yes/No)","Are upgrades planned? (Yes/No)","Is maintenance done regularly? (Yes/No)","Are outages monitored? (Yes/No)"] }
+  ],
+  "Lack of Proper Street Lighting": [
+    { stakeholder: "Households", count: 7, questions: ["Are streetlights sufficient in your area? (Yes/No)","Are lights functional at night? (Yes/No)","Are repairs done quickly? (Yes/No)","Do you feel unsafe due to lack of lighting? (Yes/No)","Are dark spots common? (Yes/No)","Are lights energy-efficient (LED)? (Yes/No)","Are poles properly placed? (Yes/No)"] },
+    { stakeholder: "Women/Students", count: 6, questions: ["Do you feel unsafe walking at night? (Yes/No)","Are certain areas completely dark? (Yes/No)","Do you avoid going out at night? (Yes/No)","Are roads visible clearly at night? (Yes/No)","Are incidents reported due to darkness? (Yes/No)","Do lights improve safety? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Are streetlights monitored regularly? (Yes/No)","Is maintenance budget available? (Yes/No)","Are faulty lights repaired quickly? (Yes/No)","Are solar lights installed? (Yes/No)","Are new lights being added? (Yes/No)","Are complaints tracked? (Yes/No)"] }
+  ],
+  "Poor Sanitation Infrastructure": [
+    { stakeholder: "Households", count: 8, questions: ["Do you have a toilet at home? (Yes/No)","Do all members use it regularly? (Yes/No)","Is open defecation still practiced? (Yes/No)","Is waste disposed properly? (Yes/No)","Do you face sanitation-related health issues? (Yes/No)","Is garbage collection available? (Yes/No)","Are surroundings clean? (Yes/No)","Are public toilets available? (Yes/No)"] },
+    { stakeholder: "Health Workers", count: 6, questions: ["Are sanitation-related diseases common? (Yes/No)","Is hygiene awareness low? (Yes/No)","Are campaigns conducted? (Yes/No)","Is waste management poor? (Yes/No)","Are children affected more? (Yes/No)","Is monitoring done regularly? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Is waste collected regularly? (Yes/No)","Are sanitation workers sufficient? (Yes/No)","Are toilets maintained? (Yes/No)","Are awareness programs conducted? (Yes/No)","Are funds sufficient? (Yes/No)","Are sanitation plans implemented? (Yes/No)"] }
+  ],
+  "Limited Access to Safe Drinking Water Infrastructure": [
+    { stakeholder: "Households", count: 10, questions: ["Do you receive drinking water daily? (Yes/No)","Is the water supply sufficient for your family? (Yes/No)","Do you face water shortages during summer? (Yes/No)","Do you depend on borewell/tanker for drinking water? (Yes/No)","Is the water quality safe for drinking? (Yes/No)","Do you treat water before drinking? (Yes/No)","Is pipeline supply available in your house? (Yes/No)","Do you experience leakage in water pipelines? (Yes/No)","Is water supply timing irregular? (Yes/No)","Has water availability reduced over the years? (Yes/No)"] },
+    { stakeholder: "Water Supply Workers", count: 8, questions: ["Is water supply provided regularly to all areas? (Yes/No)","Are pipelines in good condition? (Yes/No)","Are leakages common in the system? (Yes/No)","Is water treated before supply? (Yes/No)","Are storage tanks cleaned regularly? (Yes/No)","Is infrastructure sufficient for current demand? (Yes/No)","Are complaints from households frequent? (Yes/No)","Is maintenance done proactively? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 8, questions: ["Is there a proper drinking water supply system in the village? (Yes/No)","Are all households connected to pipelines? (Yes/No)","Is water quality tested regularly? (Yes/No)","Are funds allocated for maintenance? (Yes/No)","Are water shortages common in summer? (Yes/No)","Are alternative water sources available? (Yes/No)","Are repairs done quickly when issues arise? (Yes/No)","Are future improvements planned? (Yes/No)"] }
+  ],
+  "Poor Digital & Internet Connectivity": [
+    { stakeholder: "Students", count: 6, questions: ["Do you have internet access at home? (Yes/No)","Is connection stable? (Yes/No)","Does poor internet affect studies? (Yes/No)","Do you attend online classes? (Yes/No)","Do you use digital services? (Yes/No)","Is network speed sufficient? (Yes/No)"] },
+    { stakeholder: "Households", count: 6, questions: ["Is internet available in your area? (Yes/No)","Do you use mobile data regularly? (Yes/No)","Is connectivity reliable? (Yes/No)","Do you face signal issues? (Yes/No)","Are digital services accessible? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Service Providers", count: 6, questions: ["Is network coverage adequate? (Yes/No)","Are complaints frequent? (Yes/No)","Is infrastructure sufficient? (Yes/No)","Are expansions planned? (Yes/No)","Is maintenance regular? (Yes/No)","Are improvements visible? (Yes/No)"] }
+  ],
+  "Inadequate Public Transport Facilities": [
+    { stakeholder: "Public", count: 7, questions: ["Is public transport available regularly? (Yes/No)","Do buses reach your area? (Yes/No)","Is transport affordable? (Yes/No)","Do you face difficulty reaching towns? (Yes/No)","Are timings convenient? (Yes/No)","Are roads connected to transport routes? (Yes/No)","Do students face travel issues? (Yes/No)"] },
+    { stakeholder: "Drivers", count: 6, questions: ["Are routes sufficient? (Yes/No)","Is road condition good? (Yes/No)","Is demand high? (Yes/No)","Are schedules maintained? (Yes/No)","Are issues faced during operation? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Are transport services available? (Yes/No)","Are routes planned? (Yes/No)","Are complaints addressed? (Yes/No)","Is coordination with agencies done? (Yes/No)","Are improvements planned? (Yes/No)","Are funds available? (Yes/No)"] }
+  ],
+  "Poor Solid Waste Management Systems": [
+    { stakeholder: "Households", count: 8, questions: ["Is garbage collected regularly? (Yes/No)","Do you segregate waste? (Yes/No)","Is waste dumped openly? (Yes/No)","Are surroundings clean? (Yes/No)","Do you face smell issues? (Yes/No)","Are dustbins available? (Yes/No)","Do you burn waste? (Yes/No)","Are awareness programs conducted? (Yes/No)"] },
+    { stakeholder: "Sanitation Workers", count: 6, questions: ["Is collection done regularly? (Yes/No)","Is manpower sufficient? (Yes/No)","Are tools adequate? (Yes/No)","Are routes covered? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Is waste management system in place? (Yes/No)","Are funds sufficient? (Yes/No)","Are workers deployed? (Yes/No)","Are complaints addressed? (Yes/No)","Are improvements planned? (Yes/No)","Is monitoring done? (Yes/No)"] }
+  ],
+  "Lack of Public Infrastructure (Schools, Health Centers, Community Spaces)": [
+    { stakeholder: "Citizens", count: 7, questions: ["Are schools accessible? (Yes/No)","Are health centers available? (Yes/No)","Are facilities well maintained? (Yes/No)","Do you face difficulty accessing services? (Yes/No)","Are staff available regularly? (Yes/No)","Are buildings in good condition? (Yes/No)","Are services sufficient? (Yes/No)"] },
+    { stakeholder: "Staff", count: 6, questions: ["Are facilities adequate? (Yes/No)","Are resources sufficient? (Yes/No)","Is infrastructure maintained? (Yes/No)","Are challenges present? (Yes/No)","Are improvements needed? (Yes/No)","Are services accessible? (Yes/No)"] },
+    { stakeholder: "Panchayat", count: 6, questions: ["Are public buildings maintained? (Yes/No)","Are funds allocated? (Yes/No)","Are improvements planned? (Yes/No)","Are services monitored? (Yes/No)","Are complaints addressed? (Yes/No)","Are new facilities planned? (Yes/No)"] }
+  ]
+};

--- a/my-app/src/app/(pages)/dashboard/student/page.js
+++ b/my-app/src/app/(pages)/dashboard/student/page.js
@@ -14,67 +14,66 @@ import Reports from './_components/submissions/reports';
 import FinalReport from './_components/finalReport/page';
 import ProblemStatement from './_components/problemStatment/page';
 import SurveyQuestions from './_components/survey/page';
+import DailyTasks from './_components/dailyTasks/page';
 
 export default function StudentDashboard() {
-  const { user } = useAuth();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { user, isLoading: authLoading } = useAuth();
+  const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState(null);
   const [activeSection, setActiveSection] = useState('overview');
-  const [studentData, setStudentData] = useState(null);
+  const [studentData, setStudentData]     = useState(null);
+  const [slotEnabled, setSlotEnabled]     = useState(false); // default locked
 
   useEffect(() => {
-    const fetchStudentData = async () => {
-      if (!user?.username) {
-        setLoading(false);
-        return;
-      }
+    const fetchAll = async () => {
+      if (authLoading) return;
+      if (!user?.username) { setLoading(false); return; }
 
       try {
+        setLoading(true);
         setError(null);
-        const response = await fetch('/api/dashboard/student/data', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username: user.username })
-        });
 
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-          throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
+        // Fetch student data + slot status in parallel
+        const [studentRes, slotRes] = await Promise.all([
+          fetch('/api/dashboard/student/data', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username: user.username }),
+          }),
+          fetch('/api/slot-status', { credentials: 'include' }),
+        ]);
+
+        if (!studentRes.ok) {
+          const errData = await studentRes.json().catch(() => ({}));
+          throw new Error(errData.message || `HTTP error! status: ${studentRes.status}`);
         }
 
-        const data = await response.json();
-        if (data.success && data.student) {
-          setStudentData(data.student);
-        } else {
-          throw new Error(data.error || 'Failed to fetch student data');
-        }
-      } catch (error) {
-        console.error('Error fetching data:', error);
-        setError(error.message || 'Failed to load student data');
-        toast.error(error.message || 'Failed to load student data');
+        const [data, slotData] = await Promise.all([studentRes.json(), slotRes.json()]);
+
+        if (data.success && data.student) setStudentData(data.student);
+        else throw new Error(data.error || 'Failed to fetch student data');
+
+        setSlotEnabled(slotData.enabled === true);
+      } catch (err) {
+        console.error('Error fetching data:', err);
+        setError(err.message || 'Failed to load student data');
+        toast.error(err.message || 'Failed to load student data');
       } finally {
         setLoading(false);
       }
     };
 
-    fetchStudentData();
-  }, [user]);
+    fetchAll();
+  }, [user, authLoading]);
 
-  if (!user) {
-    return <Loader />;
-  }
+  if (!user || authLoading) return <Loader />;
+  if (loading) return <Loader />;
+  if (error)   return <div className="error">{error}</div>;
 
-  if (loading) {
-    return <Loader />;
-  }
+  const handleSectionClick = (section) => setActiveSection(section);
 
-  if (error) {
-    return <div className="error">{error}</div>;
-  }
-
-  const handleSectionClick = (section) => {
-    setActiveSection(section);
-  };
+  // Whether this student's mentor is assigned
+  const hasMentor = Boolean(studentData?.facultyMentorId || studentData?.mentor);
 
   return (
     <div className="student-dashboard">
@@ -82,49 +81,87 @@ export default function StudentDashboard() {
 
       <div className="dashboard-content">
         <nav className="dashboard-sidebar">
-          <button
-            className={`sidebar-item ${activeSection === 'overview' ? 'active' : ''}`}
-            onClick={() => handleSectionClick('overview')}
-          >
+          {/* ── Always visible ── */}
+          <button className={`sidebar-item ${activeSection === 'overview' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('overview')}>
             <span className="item-label">Overview</span>
           </button>
-          <button
-            className={`sidebar-item ${activeSection === 'profile' ? 'active' : ''}`}
-            onClick={() => handleSectionClick('profile')}
-          >
+          <button className={`sidebar-item ${activeSection === 'profile' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('profile')}>
             <span className="item-label">Profile</span>
           </button>
-          <button
-            className={`sidebar-item ${activeSection === 'change-password' ? 'active' : ''}`}
-            onClick={() => handleSectionClick('change-password')}
-          >
+          <button className={`sidebar-item ${activeSection === 'change-password' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('change-password')}>
             <span className="item-label">Change Password</span>
           </button>
-          {studentData?.problemStatementData && (
-            <button
-              className={`sidebar-item ${activeSection === 'survey' ? 'active' : ''}`}
-              onClick={() => handleSectionClick('survey')}
-            >
-              <span className="item-label">Survey Questions</span>
+
+          {/* Mentor — always visible when assigned, no slot needed */}
+          {hasMentor && (
+            <button className={`sidebar-item ${activeSection === 'lead' ? 'active' : ''}`}
+              onClick={() => handleSectionClick('lead')}>
+              <span className="item-label">My Mentor</span>
             </button>
+          )}
+
+          {/* ── Slot-gated sections ── */}
+          {slotEnabled && (
+            <>
+              <button className={`sidebar-item ${activeSection === 'daily-tasks' ? 'active' : ''}`}
+                onClick={() => handleSectionClick('daily-tasks')}>
+                <span className="item-label">Daily Tasks</span>
+              </button>
+              {studentData?.problemStatementData && (
+                <button className={`sidebar-item ${activeSection === 'survey' ? 'active' : ''}`}
+                  onClick={() => handleSectionClick('survey')}>
+                  <span className="item-label">Survey Questions</span>
+                </button>
+              )}
+            </>
+          )}
+
+          {/* Locked notice */}
+          {!slotEnabled && (
+            <div style={{
+              margin: '16px 12px 0',
+              background: '#fff8e1',
+              border: '1.5px solid #ffe082',
+              borderRadius: 10,
+              padding: '10px 12px',
+              fontSize: '0.78rem',
+              color: '#e65100',
+              lineHeight: 1.5,
+            }}>
+              🔒 Your slot is not yet active. Other sections will unlock when your slot opens.
+            </div>
           )}
         </nav>
 
         <main className="dashboard-main">
-          {activeSection === 'overview' ? <Overview user={user} studentData={studentData} /> : 
-           activeSection === 'profile' ? <Profile user={user} studentData={studentData} /> :
-           activeSection === 'change-password' ? <ChangePassword user={user} /> :
-           activeSection === 'survey' ? <SurveyQuestions studentData={studentData} /> :
-           <div style={{
-             display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-             padding: '60px 24px', textAlign: 'center', gap: '16px'
-           }}>
-             <div style={{ fontSize: '3rem' }}>🚧</div>
-             <h2 style={{ fontSize: '1.5rem', fontWeight: '700', color: '#014a01', margin: 0 }}>Coming Soon</h2>
-             <p style={{ color: '#555', fontSize: '1rem', maxWidth: '400px', lineHeight: '1.6' }}>
-               This section is under preparation and will be available soon. Please check back later.
-             </p>
-           </div>
+          {activeSection === 'overview'         ? <Overview user={user} studentData={studentData} /> :
+           activeSection === 'profile'          ? <Profile user={user} studentData={studentData} /> :
+           activeSection === 'change-password'  ? <ChangePassword user={user} /> :
+           activeSection === 'lead'             ? <Lead studentData={studentData} /> :
+           // Slot-gated
+           activeSection === 'daily-tasks' && slotEnabled  ? <DailyTasks studentData={studentData} /> :
+           activeSection === 'survey'      && slotEnabled  ? <SurveyQuestions studentData={studentData} /> :
+           // Fallback if slot not enabled but somehow navigated here
+           !slotEnabled && (activeSection === 'daily-tasks' || activeSection === 'survey') ? (
+             <div style={{ display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', padding:'60px 24px', textAlign:'center', gap:16 }}>
+               <div style={{ fontSize:'3rem' }}>🔒</div>
+               <h2 style={{ fontSize:'1.4rem', fontWeight:700, color:'#014a01', margin:0 }}>Slot Not Active Yet</h2>
+               <p style={{ color:'#555', fontSize:'0.95rem', maxWidth:380, lineHeight:1.6 }}>
+                 This section will be available once your internship slot is activated by the admin. Please check back soon.
+               </p>
+             </div>
+           ) : (
+             <div style={{ display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', padding:'60px 24px', textAlign:'center', gap:16 }}>
+               <div style={{ fontSize:'3rem' }}>🚧</div>
+               <h2 style={{ fontSize:'1.5rem', fontWeight:'700', color:'#014a01', margin:0 }}>Coming Soon</h2>
+               <p style={{ color:'#555', fontSize:'1rem', maxWidth:'400px', lineHeight:'1.6' }}>
+                 This section is under preparation and will be available soon.
+               </p>
+             </div>
+           )
           }
         </main>
       </div>

--- a/my-app/src/app/(pages)/dashboard/studentLead/_components/dailyTasksViewer/page.js
+++ b/my-app/src/app/(pages)/dashboard/studentLead/_components/dailyTasksViewer/page.js
@@ -1,0 +1,323 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+const DAY_LABELS = {
+  1: 'Day 1 – Problem Statement Understanding',
+  2: 'Day 2 – Stakeholder 1 Survey (8 Persons)',
+  3: 'Day 3 – Stakeholder 2 Survey (3 Persons)',
+  4: 'Day 4 – Stakeholder 3 Survey (3 Persons)',
+  5: 'Day 5 – Data Analysis',
+  6: 'Day 6 – Intervention Activity',
+  7: 'Day 7 – Documentation & Presentation',
+};
+
+const DAYS_WITH_COUNTS = { 2: 8, 3: 3, 4: 3 };
+
+export default function DailyTasksViewer() {
+  const [students, setStudents] = useState([]);
+  const [loading, setLoading]   = useState(true);
+  const [search, setSearch]     = useState('');
+  const [selected, setSelected] = useState(null);
+  const [activeDay, setActiveDay] = useState(1);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res  = await fetch('/api/dashboard/mentor/daily-tasks');
+        const json = await res.json();
+        setStudents(json.data || []);
+      } catch (e) { console.error(e); }
+      finally { setLoading(false); }
+    })();
+  }, []);
+
+  const filtered = students.filter(s =>
+    !search ||
+    s.name?.toLowerCase().includes(search.toLowerCase()) ||
+    s.username?.toLowerCase().includes(search.toLowerCase()) ||
+    s.problem_statement?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const submitted = (s) => Object.keys(s.days || {}).length;
+
+  if (loading) return <div style={S.wrap}><p style={{color:'#888'}}>Loading…</p></div>;
+
+  return (
+    <div style={S.wrap}>
+      <div style={S.header}>
+        <h2 style={S.h2}>📋 Daily Tasks – Student Submissions</h2>
+        <p style={S.sub}>View each student&apos;s daily task submissions for evaluation.</p>
+      </div>
+
+      {students.length === 0 ? (
+        <div style={S.empty}>No daily task submissions yet.</div>
+      ) : (
+        <div style={{ display:'grid', gridTemplateColumns: selected ? '320px 1fr' : '1fr', gap:20, alignItems:'start' }}>
+
+          {/* ── Student list ── */}
+          <div>
+            <input
+              type="text"
+              placeholder="Search name / username / PS…"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              style={S.search}
+            />
+            <div style={{ display:'flex', flexDirection:'column', gap:10 }}>
+              {filtered.map(s => (
+                <div
+                  key={s.username}
+                  onClick={() => { setSelected(s); setActiveDay(1); }}
+                  style={{
+                    ...S.card,
+                    border: `2px solid ${selected?.username === s.username ? '#014a01' : '#e9ecef'}`,
+                    background: selected?.username === s.username ? '#f0f7f0' : '#fff',
+                  }}
+                >
+                  <div style={S.cardName}>{s.name}</div>
+                  <div style={S.cardSub}>@{s.username} · {s.branch}</div>
+                  <div style={S.cardPS}>{s.problem_statement || '—'}</div>
+                  <div style={{ display:'flex', gap:8, marginTop:8, flexWrap:'wrap' }}>
+                    {[1,2,3,4,5,6,7].map(d => (
+                      <span key={d} style={{
+                        padding:'2px 8px', borderRadius:10, fontSize:'0.75rem', fontWeight:700,
+                        background: s.days[d] ? '#014a01' : '#f0f0f0',
+                        color: s.days[d] ? '#fff' : '#bbb',
+                      }}>D{d}</span>
+                    ))}
+                    <span style={S.countBadge}>{submitted(s)}/7 days</span>
+                  </div>
+                </div>
+              ))}
+              {filtered.length === 0 && <p style={{color:'#888',fontSize:'0.88rem'}}>No matches.</p>}
+            </div>
+          </div>
+
+          {/* ── Detail panel ── */}
+          {selected && (
+            <div style={S.detail}>
+              <div style={S.detailHead}>
+                <div>
+                  <h3 style={S.detailName}>{selected.name}</h3>
+                  <span style={S.domainBadge}>{selected.domain}</span>
+                  <p style={S.detailPS}><strong>PS:</strong> {selected.problem_statement || '—'}</p>
+                  <p style={S.detailUser}>@{selected.username}</p>
+                </div>
+                <button onClick={() => setSelected(null)} style={S.closeBtn}>✕ Close</button>
+              </div>
+
+              {/* Day tabs */}
+              <div style={S.dayTabs}>
+                {[1,2,3,4,5,6,7].map(d => {
+                  const dd = selected.days[d];
+                  return (
+                    <button key={d}
+                      onClick={() => setActiveDay(d)}
+                      title={dd ? `Submitted: ${new Date(dd.submittedAt||dd.updatedAt).toLocaleString('en-IN')}` : 'Not submitted'}
+                      style={{
+                        ...S.dayTab,
+                        background: activeDay === d ? '#014a01' : dd ? '#e6f4ea' : '#f5f5f5',
+                        color: activeDay === d ? '#fff' : dd ? '#014a01' : '#aaa',
+                        border: `1.5px solid ${activeDay === d ? '#014a01' : dd ? '#b7dfb7' : '#e0e0e0'}`,
+                      }}
+                    >
+                      Day {d} {dd ? '✓' : ''}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Day content */}
+              <DayDetail dayNum={activeDay} dayData={selected.days[activeDay]} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Day detail renderer ── */
+function DayDetail({ dayNum, dayData }) {
+  if (!dayData) return (
+    <div style={S.notSubmitted}>
+      <div style={{ fontSize:'2rem' }}>📭</div>
+      <p>Day {dayNum} not submitted yet.</p>
+    </div>
+  );
+
+  const { data, submittedAt, updatedAt } = dayData;
+  const fmt = (ts) => ts ? new Date(ts).toLocaleString('en-IN', {
+    day:'numeric', month:'short', year:'numeric',
+    hour:'2-digit', minute:'2-digit', second:'2-digit', hour12:true
+  }) : '—';
+
+  return (
+    <div>
+      <div style={S.dayLabel}>{DAY_LABELS[dayNum]}</div>
+
+      {/* Timestamp banner */}
+      <div style={S.tsBanner}>
+        <div style={S.tsItem}>
+          <span style={S.tsIcon}>📥</span>
+          <div>
+            <div style={S.tsTitle}>First Submitted</div>
+            <div style={S.tsVal}>{fmt(submittedAt)}</div>
+          </div>
+        </div>
+        <div style={S.tsDivider} />
+        <div style={S.tsItem}>
+          <span style={S.tsIcon}>🔄</span>
+          <div>
+            <div style={S.tsTitle}>Last Updated</div>
+            <div style={S.tsVal}>{fmt(updatedAt)}</div>
+          </div>
+        </div>
+      </div>
+
+      {dayNum === 1 && <Day1View data={data} />}
+      {(dayNum === 2 || dayNum === 3 || dayNum === 4) && <SurveyView dayNum={dayNum} data={data} />}
+      {dayNum === 5 && <InfoView text="Day 5 is auto-generated analysis on the student&apos;s end. No separate submission required." />}
+      {dayNum === 6 && <Day6View data={data} />}
+      {dayNum === 7 && <Day7View data={data} />}
+    </div>
+  );
+}
+
+function Day1View({ data }) {
+  const text  = data?.inference || '';
+  const words = text.trim() ? text.trim().split(/\s+/).length : 0;
+  return (
+    <div>
+      <div style={{ display:'flex', justifyContent:'space-between', marginBottom:8 }}>
+        <label style={S.fieldLabel}>Inference &amp; Analysis</label>
+        <span style={{ fontSize:'0.8rem', color: words>=100?'#014a01':'#e65100', fontWeight:700 }}>{words} words</span>
+      </div>
+      <div style={S.textBox}>{text || <em style={{color:'#bbb'}}>No content</em>}</div>
+    </div>
+  );
+}
+
+function SurveyView({ dayNum, data }) {
+  const count = DAYS_WITH_COUNTS[dayNum];
+  const persons = Array.from({ length: count }, (_, i) => i+1);
+  const [activePerson, setActivePerson] = useState(1);
+  const pd = data?.[`p${activePerson}`] || {};
+
+  return (
+    <div>
+      <div style={{ display:'flex', gap:8, flexWrap:'wrap', marginBottom:14 }}>
+        {persons.map(p => {
+          const d = data?.[`p${p}`];
+          const done = d?.name && Object.keys(d?.answers||{}).length>0;
+          return (
+            <button key={p} onClick={() => setActivePerson(p)} style={{
+              padding:'5px 14px', borderRadius:20, border:`1.5px solid ${activePerson===p?'#014a01':'#ccc'}`,
+              background: activePerson===p ? '#014a01' : done ? '#f0faf0' : '#f5f5f5',
+              color: activePerson===p ? '#fff' : done ? '#2e7d32' : '#888',
+              fontWeight:700, fontSize:'0.82rem', cursor:'pointer',
+            }}>
+              P{p} {done?'✓':''}
+            </button>
+          );
+        })}
+      </div>
+      <div style={S.personCard}>
+        <p style={S.fieldLabel}>Name: <strong>{pd.name || <em style={{color:'#bbb',fontWeight:400}}>Not entered</em>}</strong></p>
+        {pd.answers && Object.keys(pd.answers).length > 0 ? (
+          <div style={{ display:'flex', flexDirection:'column', gap:8, marginTop:10 }}>
+            {Object.entries(pd.answers).map(([qi, ans]) => (
+              <div key={qi} style={{ display:'flex', justifyContent:'space-between', alignItems:'center', padding:'8px 12px', background:'#f8f8f8', borderRadius:8, fontSize:'0.85rem' }}>
+                <span style={{color:'#555'}}>Q{parseInt(qi)+1}</span>
+                <span style={{
+                  padding:'2px 14px', borderRadius:12, fontWeight:700, fontSize:'0.8rem',
+                  background: ans==='Yes' ? '#d4edda' : '#fdecea',
+                  color: ans==='Yes' ? '#155724' : '#721c24',
+                }}>{ans}</span>
+              </div>
+            ))}
+          </div>
+        ) : <p style={{color:'#bbb',fontSize:'0.85rem',marginTop:8}}>No answers recorded.</p>}
+      </div>
+    </div>
+  );
+}
+
+function Day6View({ data }) {
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:14 }}>
+      <div>
+        <label style={S.fieldLabel}>Google Drive Link</label>
+        {data?.driveLink
+          ? <a href={data.driveLink} target="_blank" rel="noreferrer" style={S.link}>{data.driveLink}</a>
+          : <p style={S.empty2}>Not submitted</p>}
+      </div>
+      <div>
+        <label style={S.fieldLabel}>Activity Description</label>
+        <div style={S.textBox}>{data?.notes || <em style={{color:'#bbb'}}>No description</em>}</div>
+      </div>
+    </div>
+  );
+}
+
+function Day7View({ data }) {
+  const fields = [
+    { label: 'Case Study Document', key: 'caseStudyLink' },
+    { label: 'YouTube Video Link',  key: 'youtubeLink' },
+    { label: 'LinkedIn Post Link',  key: 'linkedinLink' },
+  ];
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:14 }}>
+      {fields.map(({ label, key }) => (
+        <div key={key}>
+          <label style={S.fieldLabel}>{label}</label>
+          {data?.[key]
+            ? <a href={data[key]} target="_blank" rel="noreferrer" style={S.link}>{data[key]}</a>
+            : <p style={S.empty2}>Not submitted</p>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function InfoView({ text }) {
+  return <div style={{ padding:'20px', background:'#f0f7f0', borderRadius:10, color:'#555', fontSize:'0.88rem' }}>{text}</div>;
+}
+
+/* ── Styles ── */
+const S = {
+  wrap:   { padding:24, maxWidth:1100, margin:'0 auto' },
+  header: { marginBottom:20 },
+  h2:     { fontSize:'1.4rem', fontWeight:700, color:'#014a01', margin:'0 0 4px' },
+  sub:    { color:'#666', fontSize:'0.88rem', margin:0 },
+  search: { width:'100%', padding:'9px 13px', borderRadius:8, border:'1.5px solid #ccc', fontSize:'0.92rem', marginBottom:12, boxSizing:'border-box' },
+  empty:  { textAlign:'center', padding:'40px 20px', background:'#f8f9fa', borderRadius:12, color:'#888' },
+  empty2: { color:'#bbb', fontSize:'0.85rem', margin:'4px 0 0' },
+  card:   { background:'#fff', borderRadius:12, padding:'14px 16px', cursor:'pointer', transition:'all 0.15s' },
+  cardName: { fontWeight:700, color:'#1a1a1a', fontSize:'0.95rem' },
+  cardSub:  { fontSize:'0.8rem', color:'#888', marginTop:2 },
+  cardPS:   { fontSize:'0.78rem', color:'#555', marginTop:4, lineHeight:1.4 },
+  countBadge: { marginLeft:'auto', padding:'2px 10px', borderRadius:10, fontSize:'0.75rem', fontWeight:700, background:'#e6f4ea', color:'#014a01' },
+  detail:     { background:'#fff', border:'1.5px solid #d0e8d0', borderRadius:14, padding:24 },
+  detailHead: { display:'flex', justifyContent:'space-between', alignItems:'flex-start', marginBottom:18, borderBottom:'2px solid #f0f0f0', paddingBottom:14 },
+  detailName: { margin:'0 0 6px', color:'#1a1a1a', fontSize:'1.1rem' },
+  detailPS:   { color:'#555', fontSize:'0.88rem', margin:'6px 0 0' },
+  detailUser: { color:'#888', fontSize:'0.8rem', margin:'2px 0 0' },
+  domainBadge: { background:'#e3f2fd', color:'#1565c0', padding:'3px 12px', borderRadius:20, fontSize:'0.78rem', fontWeight:700 },
+  closeBtn:   { padding:'6px 16px', border:'1.5px solid #ccc', borderRadius:8, background:'#fff', cursor:'pointer', fontWeight:600, fontSize:'0.85rem', color:'#555', whiteSpace:'nowrap' },
+  dayTabs:    { display:'flex', flexWrap:'wrap', gap:8, marginBottom:18 },
+  dayTab:     { padding:'6px 14px', borderRadius:20, fontWeight:700, fontSize:'0.82rem', cursor:'pointer', transition:'all 0.15s', whiteSpace:'nowrap' },
+  dayLabel:   { marginBottom:14, fontWeight:700, color:'#014a01', fontSize:'0.95rem' },
+  ts:         { fontSize:'0.75rem', color:'#888', fontWeight:400 },
+  tsBanner:   { display:'flex', alignItems:'center', gap:0, background:'#f0f7f0', border:'1.5px solid #b7dfb7', borderRadius:10, padding:'12px 16px', marginBottom:18, flexWrap:'wrap' },
+  tsItem:     { display:'flex', alignItems:'center', gap:10, flex:1, minWidth:200 },
+  tsIcon:     { fontSize:'1.3rem', flexShrink:0 },
+  tsTitle:    { fontSize:'0.72rem', fontWeight:700, color:'#666', textTransform:'uppercase', letterSpacing:'0.04em' },
+  tsVal:      { fontSize:'0.88rem', fontWeight:700, color:'#014a01', marginTop:2 },
+  tsDivider:  { width:1, background:'#b7dfb7', alignSelf:'stretch', margin:'0 16px' },
+  fieldLabel: { display:'block', fontWeight:600, color:'#333', fontSize:'0.85rem', marginBottom:4 },
+  textBox:    { background:'#f9f9f9', border:'1px solid #eee', borderRadius:8, padding:'12px 14px', fontSize:'0.88rem', color:'#333', lineHeight:1.6, whiteSpace:'pre-wrap', minHeight:80 },
+  link:       { display:'block', color:'#1565c0', fontSize:'0.88rem', wordBreak:'break-all', marginTop:4, textDecoration:'underline' },
+  personCard: { background:'#f9f9f9', border:'1px solid #eee', borderRadius:10, padding:'14px 16px' },
+  notSubmitted: { textAlign:'center', padding:'40px', color:'#888', fontSize:'0.88rem' },
+};

--- a/my-app/src/app/(pages)/dashboard/studentLead/page.js
+++ b/my-app/src/app/(pages)/dashboard/studentLead/page.js
@@ -11,6 +11,7 @@ import Students from './_components/students/page';
 import CompletedStudents from './_components/completedStudents/page';
 import FinalReports from './_components/finalReports/page';
 import SurveyResponses from './_components/surveyResponses/page';
+import DailyTasksViewer from './_components/dailyTasksViewer/page';
 
 export default function StudentLeadDashboard() {
   const { user, isLoading, isAuthenticated } = useAuth();
@@ -59,6 +60,12 @@ export default function StudentLeadDashboard() {
             <span className="item-label">Final Reports</span>
           </button>
           <button
+            className={`sidebar-item ${activeSection === 'daily-tasks' ? 'active' : ''}`}
+            onClick={() => handleSectionClick('daily-tasks')}
+          >
+            <span className="item-label">Daily Tasks</span>
+          </button>
+          <button
             className={`sidebar-item ${activeSection === 'survey-responses' ? 'active' : ''}`}
             onClick={() => handleSectionClick('survey-responses')}
           >
@@ -83,6 +90,7 @@ export default function StudentLeadDashboard() {
            activeSection === 'profile' ? <Profile user={user} /> :
            activeSection === 'students' ? <Students user={user} /> :
            activeSection === 'final-reports' ? <FinalReports user={user} /> : 
+           activeSection === 'daily-tasks' ? <DailyTasksViewer /> :
            activeSection === 'survey-responses' ? <SurveyResponses user={user} /> :
            activeSection === 'completed-students' ? <CompletedStudents user={user} /> :
            activeSection === 'change-password' ? <ChangePassword user={user} /> : null}

--- a/my-app/src/app/api/dashboard/admin/problemStatements/route.js
+++ b/my-app/src/app/api/dashboard/admin/problemStatements/route.js
@@ -94,6 +94,15 @@ export async function GET(req) {
             'SELECT COUNT(*) as total FROM registrations'
         );
 
+        // List of students who have NOT submitted a problem statement
+        const [notSubmittedList] = await pool.query(`
+            SELECT r.username, r.name, r.slot, r.mode, r.selectedDomain, r.branch
+            FROM registrations r
+            LEFT JOIN problemStatements p ON r.username = p.username
+            WHERE p.username IS NULL
+            ORDER BY r.slot ASC, r.username ASC
+        `);
+
         const total = totalCount[0].total;
         const totalPages = Math.ceil(total / limit);
 
@@ -115,6 +124,7 @@ export async function GET(req) {
                     byDomain: domainAnalytics,
                     byProblemStatement: problemAnalytics
                 },
+                notSubmittedList,
                 pagination: {
                     currentPage: page,
                     totalPages,

--- a/my-app/src/app/api/dashboard/admin/slot-control/route.js
+++ b/my-app/src/app/api/dashboard/admin/slot-control/route.js
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import { verifyAccessToken } from '@/lib/jwt';
+import { cookies } from 'next/headers';
+
+const ensureTable = async (db) => {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS slotControl (
+      slot      TINYINT  NOT NULL PRIMARY KEY,
+      enabled   TINYINT  NOT NULL DEFAULT 0,
+      updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    )
+  `);
+  // Seed all 9 slots if not present
+  for (let s = 1; s <= 9; s++) {
+    await db.query(
+      'INSERT IGNORE INTO slotControl (slot, enabled) VALUES (?, 0)', [s]
+    );
+  }
+};
+
+// ── GET — return all slot states (admin) ──────────────────────────────────────
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const decoded = await verifyAccessToken(token);
+    if (decoded.role !== 'admin')
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    const db = await pool.getConnection();
+    try {
+      await ensureTable(db);
+      const [rows] = await db.query('SELECT slot, enabled FROM slotControl ORDER BY slot');
+      return NextResponse.json({ success: true, slots: rows });
+    } finally { db.release(); }
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}
+
+// ── POST — toggle a slot on/off (admin only) ──────────────────────────────────
+export async function POST(request) {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const decoded = await verifyAccessToken(token);
+    if (decoded.role !== 'admin')
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    const { slot, enabled } = await request.json();
+    if (!slot || slot < 1 || slot > 9)
+      return NextResponse.json({ error: 'Invalid slot' }, { status: 400 });
+
+    const db = await pool.getConnection();
+    try {
+      await ensureTable(db);
+      await db.query(
+        'UPDATE slotControl SET enabled = ? WHERE slot = ?',
+        [enabled ? 1 : 0, slot]
+      );
+      return NextResponse.json({ success: true, slot, enabled: !!enabled });
+    } finally { db.release(); }
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/dashboard/admin/stats/route.js
+++ b/my-app/src/app/api/dashboard/admin/stats/route.js
@@ -2,158 +2,116 @@ import { NextResponse } from 'next/server';
 import pool from '@/lib/db';
 import { verifyAccessToken } from '@/lib/jwt';
 import { cookies } from 'next/headers';
+import { DOMAINS } from '@/app/Data/domains';
 
 export async function GET() {
-    try {
-        // Validate admin session using JWT
-        const cookieStore = await cookies();
-        const accessToken = await cookieStore.get('accessToken');
+  try {
+    const cookieStore = await cookies();
+    const accessToken = await cookieStore.get('accessToken');
+    if (!accessToken?.value)
+      return NextResponse.json({ success: false, error: 'Authentication required.' }, { status: 401 });
 
-        if (!accessToken?.value) {
-            return NextResponse.json({ 
-                success: false, 
-                error: 'Authentication required. Please login again.' 
-            }, { status: 401 });
-        }
+    const decoded = await verifyAccessToken(accessToken.value);
+    if (!decoded || decoded.role !== 'admin')
+      return NextResponse.json({ success: false, error: 'Access denied.' }, { status: 403 });
 
-        const decoded = await verifyAccessToken(accessToken.value);
-        if (!decoded || decoded.role !== 'admin') {
-            return NextResponse.json({ 
-                success: false, 
-                error: 'Access denied. Only admin members can view statistics.' 
-            }, { status: 403 });
-        }
+    // ── Live query: per-slot counts directly from registrations ──────────────
+    const [slotRows] = await pool.query(`
+      SELECT
+        slot,
+        COUNT(*) AS total,
+        SUM(CASE WHEN LOWER(TRIM(mode)) = 'remote'   THEN 1 ELSE 0 END) AS remote,
+        SUM(CASE WHEN LOWER(TRIM(mode)) = 'incampus'  THEN 1 ELSE 0 END) AS incampus,
+        SUM(CASE WHEN LOWER(TRIM(mode)) = 'invillage' THEN 1 ELSE 0 END) AS invillage
+      FROM registrations
+      WHERE slot IS NOT NULL
+      GROUP BY slot
+      ORDER BY slot
+    `);
 
-        // Get stats from the stats table
-        const [statsResult] = await pool.query('SELECT * FROM stats ORDER BY id DESC LIMIT 1');
-        
-        // If no stats found, return empty stats
-        if (!statsResult || statsResult.length === 0) {
-            return NextResponse.json({
-                success: true,
-                stats: {
-                    overview: {
-                        totalStudents: 0,
-                        totalCompleted: 0,
-                        totalActive: 0,
-                        completionRate: "0.00"
-                    },
-                    slots: {
-                        slot1: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot2: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot3: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot4: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot5: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot6: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot7: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot8: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                        slot9: { total: 0, remote: 0, incampus: 0, invillage: 0 }
-                    },
-                    modes: {
-                        remote: 0,
-                        incampus: 0,
-                        invillage: 0
-                    },
-                    domainStats: [],
-                    modeStats: []
-                }
-            });
-        }
+    // ── Overview totals ───────────────────────────────────────────────────────
+    const [overviewRows] = await pool.query(`
+      SELECT
+        COUNT(*) AS totalStudents,
+        SUM(CASE WHEN f.completed = 1 THEN 1 ELSE 0 END) AS totalCompleted,
+        SUM(CASE WHEN f.completed = 1 THEN 0 ELSE 1 END) AS totalActive
+      FROM registrations r
+      LEFT JOIN final f ON r.username = f.username
+    `);
+    const overview = overviewRows[0] || {};
+    const totalStudents  = Number(overview.totalStudents)  || 0;
+    const totalCompleted = Number(overview.totalCompleted) || 0;
+    const totalActive    = Number(overview.totalActive)    || 0;
 
-        const stats = statsResult[0];
+    // ── Build slots object from live data ─────────────────────────────────────
+    const slotsObj = {};
+    const availableSlots = [];
+    slotRows.forEach(row => {
+      const n = row.slot;
+      availableSlots.push(n);
+      slotsObj[`slot${n}`] = {
+        total:     Number(row.total)     || 0,
+        remote:    Number(row.remote)    || 0,
+        incampus:  Number(row.incampus)  || 0,
+        invillage: Number(row.invillage) || 0,
+      };
+    });
 
-        // Build slots object dynamically — only include slots whose columns exist in the stats row.
-        // This makes the API safe for both the old DB (4 slots) and new DB (9 slots).
-        const buildSlot = (n) => ({
-            total: stats[`slot${n}`] ?? 0,
-            remote: stats[`slot${n}Remote`] ?? 0,
-            incampus: stats[`slot${n}Incamp`] ?? 0,
-            invillage: stats[`slot${n}Invillage`] ?? 0
-        });
+    // ── Domain stats: include ALL 20 domains, even those with 0 students ──────
+    // Pull actual counts from registrations
+    const [domainRows] = await pool.query(`
+      SELECT selectedDomain, COUNT(*) AS total,
+             SUM(CASE WHEN f.completed = 1 THEN 1 ELSE 0 END) AS completed,
+             SUM(CASE WHEN f.completed = 1 THEN 0 ELSE 1 END) AS active
+      FROM registrations r
+      LEFT JOIN final f ON r.username = f.username
+      GROUP BY r.selectedDomain
+    `);
 
-        // Detect max slot number from columns present in the row
-        const allPossibleSlots = [1,2,3,4,5,6,7,8,9];
-        const availableSlots = allPossibleSlots.filter(n => stats[`slot${n}`] !== undefined);
-        const slotsObj = {};
-        availableSlots.forEach(n => { slotsObj[`slot${n}`] = buildSlot(n); });
+    // Build a map of DB results keyed by domain name
+    const dbMap = {};
+    domainRows.forEach(row => { dbMap[row.selectedDomain] = row; });
 
-        // Get domain-wise statistics
-        const [domainStats] = await pool.query(`
-            SELECT 
-                r.selectedDomain,
-                COUNT(*) as total,
-                SUM(CASE WHEN f.completed = true THEN 1 ELSE 0 END) as completed,
-                SUM(CASE WHEN f.completed = false OR f.completed IS NULL THEN 1 ELSE 0 END) as active
-            FROM registrations r
-            LEFT JOIN final f ON r.username = f.username
-            GROUP BY r.selectedDomain
-        `);
+    // Merge with full domain list so all 20 appear
+    const domainStats = DOMAINS.map(d => ({
+      selectedDomain: d.name,
+      total:     Number(dbMap[d.name]?.total     ?? 0),
+      completed: Number(dbMap[d.name]?.completed ?? 0),
+      active:    Number(dbMap[d.name]?.active    ?? 0),
+    })).sort((a, b) => b.total - a.total);
 
-        // Get mode-wise statistics
-        const [modeStats] = await pool.query(`
-            SELECT 
-                r.mode,
-                COUNT(*) as total,
-                SUM(CASE WHEN f.completed = true THEN 1 ELSE 0 END) as completed,
-                SUM(CASE WHEN f.completed = false OR f.completed IS NULL THEN 1 ELSE 0 END) as active
-            FROM registrations r
-            LEFT JOIN final f ON r.username = f.username
-            GROUP BY r.mode
-        `);
+    // ── Mode stats ────────────────────────────────────────────────────────────
+    const [modeStats] = await pool.query(`
+      SELECT
+        r.mode,
+        COUNT(*) AS total,
+        SUM(CASE WHEN f.completed = 1 THEN 1 ELSE 0 END) AS completed,
+        SUM(CASE WHEN f.completed = 1 THEN 0 ELSE 1 END) AS active
+      FROM registrations r
+      LEFT JOIN final f ON r.username = f.username
+      GROUP BY r.mode
+    `);
 
-        return NextResponse.json({
-            success: true,
-            stats: {
-                overview: {
-                    totalStudents: stats.totalStudents ?? 0,
-                    totalCompleted: stats.totalCompleted ?? 0,
-                    totalActive: stats.totalActive ?? 0,
-                    completionRate: stats.totalStudents
-                        ? ((stats.totalCompleted / stats.totalStudents) * 100).toFixed(2)
-                        : "0.00"
-                },
-                slots: slotsObj,
-                availableSlots, // tell the frontend which slots to show
-                modes: {
-                    remote: stats.remote ?? 0,
-                    incampus: stats.incampus ?? 0,
-                    invillage: stats.invillage ?? 0
-                },
-                domainStats: domainStats || [],
-                modeStats: modeStats || []
-            }
-        });
+    return NextResponse.json({
+      success: true,
+      stats: {
+        overview: {
+          totalStudents,
+          totalCompleted,
+          totalActive,
+          completionRate: totalStudents
+            ? ((totalCompleted / totalStudents) * 100).toFixed(2)
+            : '0.00',
+        },
+        slots: slotsObj,
+        availableSlots,
+        domainStats: domainStats || [],
+        modeStats:   modeStats   || [],
+      },
+    });
 
-    } catch (error) {
-        console.error('Error in admin stats endpoint:', error);
-        return NextResponse.json({
-            success: true,
-            stats: {
-                overview: {
-                    totalStudents: 0,
-                    totalCompleted: 0,
-                    totalActive: 0,
-                    completionRate: "0.00"
-                },
-                slots: {
-                    slot1: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot2: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot3: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot4: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot5: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot6: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot7: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot8: { total: 0, remote: 0, incampus: 0, invillage: 0 },
-                    slot9: { total: 0, remote: 0, incampus: 0, invillage: 0 }
-                },
-                modes: {
-                    remote: 0,
-                    incampus: 0,
-                    invillage: 0
-                },
-                domainStats: [],
-                modeStats: []
-            }
-        });
-    }
-} 
+  } catch (error) {
+    console.error('Error in admin stats endpoint:', error);
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/dashboard/mentor/daily-tasks/route.js
+++ b/my-app/src/app/api/dashboard/mentor/daily-tasks/route.js
@@ -1,0 +1,117 @@
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/lib/jwt';
+
+// GET — admin / facultyMentor / studentLead views daily tasks of their assigned students
+export async function GET(request) {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const payload = await verifyAccessToken(token);
+    const { role, username } = payload;
+
+    if (!['studentLead', 'facultyMentor', 'admin'].includes(role)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const targetUsername = searchParams.get('username');
+
+    let studentUsernames = [];
+
+    if (role === 'studentLead') {
+      const [leadRows] = await pool.query(
+        `SELECT student1Username,student2Username,student3Username,student4Username,
+                student5Username,student6Username,student7Username,student8Username,
+                student9Username,student10Username,student11Username,student12Username,
+                student13Username,student14Username,student15Username,student16Username,
+                student17Username,student18Username,student19Username,student20Username,
+                student21Username,student22Username,student23Username,student24Username,
+                student25Username,student26Username,student27Username,student28Username,
+                student29Username,student30Username
+         FROM studentLeads WHERE username = ?`,
+        [username]
+      );
+      if (!leadRows.length) return NextResponse.json({ data: [] });
+      studentUsernames = Object.values(leadRows[0]).filter(Boolean);
+
+    } else if (role === 'facultyMentor') {
+      const [students] = await pool.query(
+        `SELECT username FROM registrations WHERE facultyMentorId = ?`, [username]
+      );
+      studentUsernames = students.map(s => s.username);
+
+    } else {
+      // admin — all students or specific one
+      if (!targetUsername) {
+        const [all] = await pool.query(`SELECT username FROM registrations`);
+        studentUsernames = all.map(s => s.username);
+      }
+    }
+
+    // Fetch daily tasks
+    let query, params;
+
+    if (targetUsername) {
+      // Permission check for non-admins
+      if (role !== 'admin' && !studentUsernames.includes(targetUsername)) {
+        return NextResponse.json({ error: 'Student not assigned to you' }, { status: 403 });
+      }
+      query = `
+        SELECT dt.username, dt.day, dt.data, dt.submittedAt, dt.updatedAt,
+               r.name, r.branch, r.selectedDomain,
+               ps.problem_statement
+        FROM dailyTasks dt
+        JOIN registrations r ON dt.username = r.username
+        LEFT JOIN problemStatements ps ON dt.username = ps.username
+        WHERE dt.username = ?
+        ORDER BY dt.day
+      `;
+      params = [targetUsername];
+    } else {
+      if (studentUsernames.length === 0) return NextResponse.json({ data: [] });
+      const placeholders = studentUsernames.map(() => '?').join(',');
+      query = `
+        SELECT dt.username, dt.day, dt.data, dt.submittedAt, dt.updatedAt,
+               r.name, r.branch, r.selectedDomain,
+               ps.problem_statement
+        FROM dailyTasks dt
+        JOIN registrations r ON dt.username = r.username
+        LEFT JOIN problemStatements ps ON dt.username = ps.username
+        WHERE dt.username IN (${placeholders})
+        ORDER BY dt.username, dt.day
+      `;
+      params = studentUsernames;
+    }
+
+    const [rows] = await pool.query(query, params);
+
+    // Group by student username → { username, name, branch, domain, ps, days: { 1: data, … } }
+    const studentMap = {};
+    rows.forEach(row => {
+      if (!studentMap[row.username]) {
+        studentMap[row.username] = {
+          username: row.username,
+          name: row.name,
+          branch: row.branch,
+          domain: row.selectedDomain,
+          problem_statement: row.problem_statement,
+          days: {},
+        };
+      }
+      studentMap[row.username].days[row.day] = {
+        data: typeof row.data === 'string' ? JSON.parse(row.data) : row.data,
+        submittedAt: row.submittedAt,
+        updatedAt: row.updatedAt,
+      };
+    });
+
+    return NextResponse.json({ data: Object.values(studentMap) });
+  } catch (error) {
+    console.error('Error fetching daily tasks:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/dashboard/student/daily-tasks/route.js
+++ b/my-app/src/app/api/dashboard/student/daily-tasks/route.js
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/lib/jwt';
+
+// POST — save/update a specific day's task data
+export async function POST(request) {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const payload = await verifyAccessToken(token);
+    if (payload.role !== 'student')
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    const { day, data } = await request.json();
+    if (!day || !data)
+      return NextResponse.json({ error: 'Missing day or data' }, { status: 400 });
+
+    const db = await pool.getConnection();
+    try {
+      // Ensure table exists
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS dailyTasks (
+          id          INT          AUTO_INCREMENT PRIMARY KEY,
+          username    VARCHAR(255) NOT NULL,
+          day         TINYINT      NOT NULL,
+          data        JSON         NOT NULL,
+          submittedAt TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+          updatedAt   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uq_user_day (username, day)
+        )
+      `);
+
+      await db.execute(
+        `INSERT INTO dailyTasks (username, day, data)
+         VALUES (?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           data = VALUES(data),
+           updatedAt = CURRENT_TIMESTAMP`,
+        // submittedAt intentionally excluded from UPDATE — preserves original submission time
+        [payload.username, day, JSON.stringify(data)]
+      );
+
+      return NextResponse.json({ success: true, message: `Day ${day} saved successfully.` });
+    } finally {
+      db.release();
+    }
+  } catch (error) {
+    console.error('Error saving daily task:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+// GET — fetch all daily task submissions for the logged-in student
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const payload = await verifyAccessToken(token);
+    if (payload.role !== 'student')
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    const db = await pool.getConnection();
+    try {
+      // Ensure table exists
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS dailyTasks (
+          id          INT          AUTO_INCREMENT PRIMARY KEY,
+          username    VARCHAR(255) NOT NULL,
+          day         TINYINT      NOT NULL,
+          data        JSON         NOT NULL,
+          submittedAt TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+          updatedAt   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uq_user_day (username, day)
+        )
+      `);
+
+      const [rows] = await db.execute(
+        'SELECT day, data, submittedAt, updatedAt FROM dailyTasks WHERE username = ? ORDER BY day',
+        [payload.username]
+      );
+
+      const taskMap = {};
+      rows.forEach(row => {
+        taskMap[row.day] = {
+          data: typeof row.data === 'string' ? JSON.parse(row.data) : row.data,
+          submittedAt: row.submittedAt,
+          updatedAt: row.updatedAt,
+        };
+      });
+
+      return NextResponse.json({ success: true, tasks: taskMap });
+    } finally {
+      db.release();
+    }
+  } catch (error) {
+    console.error('Error fetching daily tasks:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/register/route.js
+++ b/my-app/src/app/api/register/route.js
@@ -81,31 +81,34 @@ export async function POST(request) {
         }
       }
 
-      // Check slot availability with retry
-      const [stats] = await retryOperation(async () => {
-        return await db.query('SELECT * FROM stats ORDER BY id DESC LIMIT 1 FOR UPDATE');
-      });
-
-      if (!stats || stats.length === 0) {
-        throw new Error('Stats not found');
-      }
-
-      const currentStats = stats[0];
-      const slotNum = parseInt(formData.slot);
-
       // Validate slot range 1-9
+      const slotNum = parseInt(formData.slot);
       if (slotNum < 1 || slotNum > 9) {
         throw new Error('Invalid slot selected');
       }
 
-      const slotField = `slot${formData.slot}`;
-      const modeField = formData.mode.toLowerCase();
-      const slotModeField = formData.mode === 'Remote' ? `slot${formData.slot}Remote` : 
-                          formData.mode === 'Incampus' ? `slot${formData.slot}Incamp` : 
-                          `slot${formData.slot}Invillage`;
+      // ── Slot + mode capacity check (live from registrations) ──────────────
+      const LIMITS = { incampus: 200, invillage: 30 }; // Remote has no limit
+      const modeKey = formData.mode?.toLowerCase();
 
-      // Registration limits have been removed as per request
-      
+      if (modeKey === 'incampus' || modeKey === 'invillage') {
+        const limit = LIMITS[modeKey];
+        const [[{ count }]] = await db.query(
+          `SELECT COUNT(*) AS count FROM registrations
+           WHERE slot = ? AND LOWER(TRIM(mode)) = ?`,
+          [formData.slot, modeKey]
+        );
+        if (Number(count) >= limit) {
+          await db.rollback();
+          const modeLabel = modeKey === 'incampus' ? 'In Campus' : 'In Village';
+          return new Response(JSON.stringify({
+            success: false,
+            message: `The ${modeLabel} mode for Slot ${formData.slot} is full (limit: ${limit} students). Please choose a different mode or a different slot.`
+          }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+      }
+      // Remote (hometown) mode: no limit — no check needed
+
       // Generate username from ID number
       const username = formData.studentInfo.idNumber;
 
@@ -266,16 +269,7 @@ export async function POST(request) {
       // Execute all queries in parallel
       await Promise.all(queries.map(q => db.query(q.query, q.values)));
 
-      // Update stats
-      await db.query(`
-        UPDATE stats 
-        SET 
-          ${slotField} = ${slotField} + 1,
-          ${modeField} = ${modeField} + 1,
-          ${slotModeField} = ${slotModeField} + 1,
-          totalStudents = totalStudents + 1
-        WHERE id = ?
-      `, [currentStats.id]);
+      // Stats are now computed live from registrations — no table update needed
 
       // Commit transaction
       await db.commit();

--- a/my-app/src/app/api/slot-status/route.js
+++ b/my-app/src/app/api/slot-status/route.js
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import { verifyAccessToken } from '@/lib/jwt';
+import { cookies } from 'next/headers';
+
+// Public-ish: any authenticated user can check their own slot status
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const decoded = await verifyAccessToken(token);
+    const username = decoded.username;
+
+    const db = await pool.getConnection();
+    try {
+      // Get the student's slot
+      const [[reg]] = await db.query(
+        'SELECT slot FROM registrations WHERE username = ?', [username]
+      );
+      if (!reg) return NextResponse.json({ enabled: false, slot: null });
+
+      const slot = reg.slot;
+
+      // Check slotControl
+      let [[ctrl]] = await db.query(
+        'SELECT enabled FROM slotControl WHERE slot = ?', [slot]
+      );
+      // If table doesn't exist yet or row missing, treat as disabled
+      const enabled = ctrl ? Boolean(ctrl.enabled) : false;
+
+      return NextResponse.json({ success: true, slot, enabled });
+    } finally { db.release(); }
+  } catch (e) {
+    // If slotControl table doesn't exist, return disabled gracefully
+    if (e.code === 'ER_NO_SUCH_TABLE') return NextResponse.json({ success: true, slot: null, enabled: false });
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/time/route.js
+++ b/my-app/src/app/api/time/route.js
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // Returns server epoch in ms — always IST (server is IST or UTC, but epoch is absolute)
+  return NextResponse.json({ ts: Date.now() });
+}

--- a/my-app/src/components/Footer.js
+++ b/my-app/src/components/Footer.js
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <footer className="dashboard-footer">
       <p>© 2026 Smart Village Revolution. All Rights Reserved.</p>
-      <p>Designed and Developed by ZeroOne CodeClub</p>
+      <p>Designed and Developed by Nischal Singana | ZeroOne CodeClub</p>
     </footer>
   );
 } 

--- a/my-app/src/context/AuthContext.js
+++ b/my-app/src/context/AuthContext.js
@@ -1,12 +1,13 @@
 'use client';
 import React, { createContext, useState, useEffect, useRef, useContext } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import toast from 'react-hot-toast';
 
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const router = useRouter();
+  const pathname = usePathname();
   const [user, setUser] = useState(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -112,6 +113,13 @@ export const AuthProvider = ({ children }) => {
       if (intervalIdRef.current) clearInterval(intervalIdRef.current);
     };
   }, []);
+
+  // Re-run auth check on route change (handles proxy login soft navigation)
+  useEffect(() => {
+    if (!mountedRef.current) return;
+    authCheckedRef.current = false;
+    checkInitialAuth();
+  }, [pathname]);
 
   // Start refresh interval when authenticated
   useEffect(() => {


### PR DESCRIPTION
- Add 7-day daily tasks for students (Days 1-7) with server-authoritative IST timing
- Sequential slot-based unlocking: Day N unlocks only after Day N-1 submitted
- Anti-cheat: all deadlines use server time via /api/time, ignoring device clock
- Add dailyTasks table (auto-created) with submittedAt + updatedAt tracking
- Add DailyTasksViewer for admin/mentor/studentLead to evaluate submissions
- Add Slot Control page in admin sidebar: toggle 9 slots on/off
- Student dashboard gated by slot: locked slots show only Overview/Profile/Password/Mentor
- Fix admin stats to compute live from registrations (no more stale stats table)
- Fix domain stats: all 20 domains shown even with 0 students
- Fix negative slot mode counts with live SQL aggregation
- Add Not Yet Submitted tab in Problem Statements with searchable ID list
- Add slot+mode capacity limits on registration (Incampus:200, InVillage:30 per slot)
- Remove dead stats table writes from registration route
- Premium admin overview UI: KPI cards, geo chart, horizontal marks bars
- Add submittedAt column to dailyTasks for first-submission tracking