### PR TITLE
fix: UI polish, stats accuracy, demo student, slot toggle

### DIFF
--- a/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.css
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.css
@@ -89,9 +89,10 @@
 /* ── Total count badge ── */
 .ov-total-badge {
   display: inline-flex; align-items: center; gap: 6px;
-  background: #e6f4ea; color: #014a01; font-weight: 700;
-  font-size: 0.88rem; padding: 5px 14px; border-radius: 20px;
+  background: #e6f4ea; color: #014a01; font-weight: 600;
+  font-size: 0.85rem; padding: 5px 16px; border-radius: 20px;
   margin-bottom: 16px; border: 1px solid #b7dfb7;
+  letter-spacing: 0.01em;
 }
 
 /* ── District toggle btn ── */

--- a/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/overview/page.js
@@ -3,14 +3,22 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import toast from 'react-hot-toast';
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
-  Legend, ResponsiveContainer, Cell
+  PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
+import {
+  TeamOutlined, CheckCircleOutlined, UserOutlined, SolutionOutlined, ReloadOutlined,
+  GlobalOutlined, BarChartOutlined
+} from '@ant-design/icons';
 import './page.css';
 
-const GEO_COLORS = ['#014a01','#1b8f2d','#4caf50','#81c784','#a5d6a7','#2e7d32','#388e3c','#43a047','#66bb6a','#c8e6c9'];
-const MARKS_COLORS = { '95–100':'#014a01','90–95':'#1b8f2d','80–89':'#4caf50','70–79':'#f9a825','60–69':'#fb8c00','Below 60':'#e53935' };
-
+const GEO_COLORS = [
+  '#014a01','#1b8f2d','#2e7d32','#388e3c','#43a047',
+  '#558b2f','#689f38','#7cb342','#9ccc65','#aed581'
+];
+const MARKS_COLORS = {
+  '95–100':'#014a01','90–95':'#1b8f2d','80–89':'#4caf50',
+  '70–79':'#f9a825','60–69':'#fb8c00','Below 60':'#e53935'
+};
 const SLOT_OPTS = [
   { v:'all', l:'All Slots' },
   { v:'1', l:'Slot 1 — May 11–17' }, { v:'2', l:'Slot 2 — May 18–24' },
@@ -19,6 +27,56 @@ const SLOT_OPTS = [
   { v:'7', l:'Slot 7 — Jun 22–28' }, { v:'8', l:'Slot 8 — Jun 29–Jul 5' },
   { v:'9', l:'Slot 9 — Jul 6–12' },
 ];
+
+/* ── Custom Pie label (outer) ── */
+const RADIAN = Math.PI / 180;
+const renderCustomLabel = ({ cx, cy, midAngle, outerRadius, name, percent }) => {
+  if (percent < 0.03) return null; // hide tiny slices
+  const r = outerRadius + 28;
+  const x = cx + r * Math.cos(-midAngle * RADIAN);
+  const y = cy + r * Math.sin(-midAngle * RADIAN);
+  return (
+    <text x={x} y={y} fill="#333" textAnchor={x > cx ? 'start' : 'end'}
+      dominantBaseline="central" fontSize={11} fontWeight={600} fontFamily="Inter, sans-serif">
+      {name} ({(percent * 100).toFixed(1)}%)
+    </text>
+  );
+};
+
+/* ── Custom tooltip ── */
+const CustomTooltip = ({ active, payload, total }) => {
+  if (!active || !payload?.length) return null;
+  const { name, value } = payload[0];
+  return (
+    <div style={{
+      background:'#fff', border:'1.5px solid #d0e8d0', borderRadius:10,
+      padding:'10px 16px', boxShadow:'0 4px 20px rgba(0,0,0,0.12)',
+      fontFamily:'Inter, sans-serif'
+    }}>
+      <div style={{ fontWeight:700, color:'#014a01', marginBottom:4 }}>{name}</div>
+      <div style={{ fontSize:'0.88rem', color:'#333' }}>
+        <strong>{value}</strong> students &nbsp;
+        <span style={{ color:'#888' }}>({total ? ((value/total)*100).toFixed(1) : 0}%)</span>
+      </div>
+    </div>
+  );
+};
+
+/* ── Custom legend ── */
+const CustomLegend = ({ data, total }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap:8, minWidth:180, paddingLeft:24 }}>
+    {data.map((d, i) => (
+      <div key={d.name} style={{ display:'flex', alignItems:'center', gap:10 }}>
+        <div style={{ width:12, height:12, borderRadius:3, background:GEO_COLORS[i % GEO_COLORS.length], flexShrink:0 }} />
+        <div style={{ flex:1, fontSize:'0.82rem', color:'#333', fontWeight:500 }}>{d.name}</div>
+        <div style={{ fontSize:'0.82rem', fontWeight:700, color:'#014a01', minWidth:28, textAlign:'right' }}>{d.value}</div>
+        <div style={{ fontSize:'0.75rem', color:'#aaa', minWidth:42, textAlign:'right' }}>
+          {total ? ((d.value/total)*100).toFixed(1) : 0}%
+        </div>
+      </div>
+    ))}
+  </div>
+);
 
 export default function Overview() {
   const { user } = useAuth();
@@ -29,13 +87,13 @@ export default function Overview() {
   const [statsLoading, setStatsLoading]   = useState(false);
   const [statsSlotFilter, setStatsSlotFilter] = useState('all');
 
-  // Geo filters
-  const [selectedState, setSelectedState]     = useState('');
+  const [selectedState, setSelectedState]       = useState('');
   const [selectedDistrict, setSelectedDistrict] = useState('');
-  const [selectedGender, setSelectedGender]   = useState('all');
+  const [selectedGender, setSelectedGender]     = useState('all');
   const [showDistrictWise, setShowDistrictWise] = useState(false);
-  const [geoSlotFilter, setGeoSlotFilter]     = useState('all');
-  const [modeFilter, setModeFilter]           = useState('all');
+  const [geoSlotFilter, setGeoSlotFilter]       = useState('all');
+  const [modeFilter, setModeFilter]             = useState('all');
+  const [activeIndex, setActiveIndex]           = useState(null);
 
   const fetchOverviewData = async () => {
     try {
@@ -67,15 +125,12 @@ export default function Overview() {
   if (error)   return <div className="error">{error}</div>;
   if (!overviewData) return <div className="no-data">No data available</div>;
 
-  const { leadsCount, studentsCount, completedCount, facultyCount,
-          stateStats, districtStats } = overviewData;
-
+  const { leadsCount, studentsCount, completedCount, facultyCount, stateStats, districtStats } = overviewData;
   const states = [...new Set(stateStats.map(s => s.state))];
   const districts = selectedState
     ? [...new Set(districtStats.filter(s => s.state === selectedState).map(s => s.district))]
     : [];
 
-  // ── Geo data builder ────────────────────────────────────────────────────────
   const filterBySlotMode = arr =>
     arr.filter(s =>
       (geoSlotFilter === 'all' || String(s.slot) === geoSlotFilter) &&
@@ -113,7 +168,6 @@ export default function Overview() {
         { name:'Other',  value: arr.reduce((a,s) => a + (Number(s.other)||0),  0) },
       ];
     }
-    // All states
     const filtered = filterBySlotMode(stateStats);
     const map = {};
     filtered.forEach(s => {
@@ -132,10 +186,8 @@ export default function Overview() {
     : selectedGender === 'all'
       ? geoData
       : geoData.map(r => ({ name: r.name, value: r[selectedGender.toLowerCase()] || 0 }));
-
   const totalFiltered = filteredGeoData.reduce((a, r) => a + r.value, 0);
 
-  // ── Marks data ──────────────────────────────────────────────────────────────
   const marksData = [
     { range:'95–100', count: statsData?.marksDistribution?.['95_to_100'] || 0, color: MARKS_COLORS['95–100'] },
     { range:'90–95',  count: statsData?.marksDistribution?.['90_to_95']  || 0, color: MARKS_COLORS['90–95'] },
@@ -147,10 +199,10 @@ export default function Overview() {
   const maxMarks = Math.max(...marksData.map(r => r.count), 1);
 
   const kpiCards = [
-    { label:'Total Students',    value: studentsCount,   icon:'👨‍🎓', color:'#014a01', bg:'#e6f4ea' },
-    { label:'Completed',         value: completedCount,  icon:'✅',   color:'#1565c0', bg:'#e3f2fd' },
-    { label:'Student Leads',     value: leadsCount,      icon:'🌟',   color:'#6a1b9a', bg:'#f3e5f5' },
-    { label:'Faculty Mentors',   value: facultyCount,    icon:'👩‍🏫', color:'#e65100', bg:'#fff3e0' },
+    { label:'Total Students',  value: studentsCount,  Icon: TeamOutlined,         color:'#014a01', bg:'#e6f4ea' },
+    { label:'Completed',       value: completedCount, Icon: CheckCircleOutlined,   color:'#1565c0', bg:'#e3f2fd' },
+    { label:'Student Leads',   value: leadsCount,     Icon: SolutionOutlined,      color:'#6a1b9a', bg:'#f3e5f5' },
+    { label:'Faculty Mentors', value: facultyCount,   Icon: UserOutlined,          color:'#e65100', bg:'#fff3e0' },
   ];
 
   return (
@@ -161,19 +213,22 @@ export default function Overview() {
           <h1>Admin Dashboard Overview</h1>
           <p>Real-time data · Last refreshed just now</p>
         </div>
-        <button className="ov-refresh-btn" onClick={() => { fetchOverviewData(); fetchStatsData(statsSlotFilter); }}>
-          🔄 Refresh
+        <button className="ov-refresh-btn"
+          onClick={() => { fetchOverviewData(); fetchStatsData(statsSlotFilter); }}>
+          <ReloadOutlined /> Refresh
         </button>
       </div>
 
       {/* ── KPI Cards ── */}
       <div className="ov-kpi-grid">
-        {kpiCards.map(k => (
-          <div key={k.label} className="ov-kpi-card" style={{ '--kpi-color': k.color, '--kpi-bg': k.bg }}>
-            <div className="ov-kpi-icon">{k.icon}</div>
+        {kpiCards.map(({ label, value, Icon, color, bg }) => (
+          <div key={label} className="ov-kpi-card" style={{ '--kpi-color': color, '--kpi-bg': bg }}>
+            <div className="ov-kpi-icon">
+              <Icon style={{ fontSize: '1.4rem', color }} />
+            </div>
             <div className="ov-kpi-info">
-              <h4>{k.label}</h4>
-              <p>{k.value}</p>
+              <h4>{label}</h4>
+              <p>{value}</p>
             </div>
           </div>
         ))}
@@ -181,7 +236,11 @@ export default function Overview() {
 
       {/* ── Geographical Distribution ── */}
       <div className="ov-section-card">
-        <h2 className="ov-section-title"><span>🗺️</span> Geographical Distribution</h2>
+        <h2 className="ov-section-title">
+          <GlobalOutlined style={{ fontSize:'1.1rem', color:'#014a01' }} />
+          Geographical Distribution
+        </h2>
+
         <div className="ov-filters">
           <div className="ov-filter-group">
             <label>State</label>
@@ -203,7 +262,7 @@ export default function Overview() {
                 <label style={{ opacity:0 }}>_</label>
                 <button className={`ov-toggle-btn${showDistrictWise ? ' active' : ''}`}
                   onClick={() => setShowDistrictWise(v => !v)}>
-                  {showDistrictWise ? '📍 District View ON' : '📍 Show District-Wise'}
+                  {showDistrictWise ? 'District View ON' : 'Show District-Wise'}
                 </button>
               </div>
             </>
@@ -234,26 +293,52 @@ export default function Overview() {
           </div>
         </div>
 
-        <div className="ov-total-badge">📊 Total: {totalFiltered} students</div>
+        <div className="ov-total-badge">
+          Total: <strong style={{ marginLeft:4 }}>{totalFiltered}</strong>&nbsp;students
+        </div>
 
         {filteredGeoData.length > 0 ? (
-          <ResponsiveContainer width="100%" height={340}>
-            <BarChart data={filteredGeoData} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e8f5e9" />
-              <XAxis dataKey="name" tick={{ fontSize: 11, fill:'#555', fontWeight:600 }} angle={-15} textAnchor="end" interval={0} />
-              <YAxis tick={{ fontSize: 11, fill:'#888' }} />
-              <Tooltip
-                contentStyle={{ background:'#fff', border:'1.5px solid #b7dfb7', borderRadius:10, boxShadow:'0 4px 16px rgba(0,0,0,0.1)' }}
-                labelStyle={{ fontWeight:700, color:'#014a01' }}
-              />
-              <Legend />
-              <Bar dataKey="value" name="Students" radius={[6,6,0,0]}>
-                {filteredGeoData.map((_, i) => (
-                  <Cell key={i} fill={GEO_COLORS[i % GEO_COLORS.length]} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <div style={{ display:'flex', alignItems:'center', gap:0, width:'100%' }}>
+            {/* Pie */}
+            <div style={{ flex:'0 0 380px', height:340 }}>
+              <ResponsiveContainer width="100%" height={340}>
+                <PieChart>
+                  <Pie
+                    data={filteredGeoData}
+                    cx="50%" cy="50%"
+                    innerRadius={72}
+                    outerRadius={130}
+                    paddingAngle={2}
+                    dataKey="value"
+                    onMouseEnter={(_, i) => setActiveIndex(i)}
+                    onMouseLeave={() => setActiveIndex(null)}
+                    stroke="none"
+                  >
+                    {filteredGeoData.map((_, i) => (
+                      <Cell
+                        key={i}
+                        fill={GEO_COLORS[i % GEO_COLORS.length]}
+                        opacity={activeIndex === null || activeIndex === i ? 1 : 0.55}
+                        style={{ cursor:'pointer', transition:'opacity 0.2s' }}
+                      />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<CustomTooltip total={totalFiltered} />} />
+                  {/* Donut centre label */}
+                  <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle"
+                    style={{ fontFamily:'Inter, sans-serif' }}>
+                    <tspan x="50%" dy="-8" fontSize={28} fontWeight={800} fill="#012a01">{totalFiltered}</tspan>
+                    <tspan x="50%" dy={22} fontSize={12} fontWeight={500} fill="#888">Students</tspan>
+                  </text>
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* Custom legend */}
+            <div style={{ flex:1, overflowY:'auto', maxHeight:320 }}>
+              <CustomLegend data={filteredGeoData} total={totalFiltered} />
+            </div>
+          </div>
         ) : (
           <div className="no-data-message">No data for selected filters</div>
         )}
@@ -263,7 +348,8 @@ export default function Overview() {
       <div className="ov-section-card">
         <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', flexWrap:'wrap', gap:12 }}>
           <h2 className="ov-section-title" style={{ margin:0, borderBottom:'none', paddingBottom:0 }}>
-            <span>📈</span> Course Statistics
+            <BarChartOutlined style={{ fontSize:'1.1rem', color:'#014a01' }} />
+            Course Statistics
           </h2>
           <div className="ov-filter-group" style={{ minWidth:200, maxWidth:260 }}>
             <label>Filter by Slot</label>
@@ -297,9 +383,8 @@ export default function Overview() {
               </div>
             </div>
 
-            {/* Marks distribution — custom horizontal bars */}
-            <h3 style={{ fontWeight:700, color:'#012a01', fontSize:'0.95rem', margin:'0 0 16px', display:'flex', alignItems:'center', gap:8 }}>
-              📊 Marks Distribution
+            <h3 style={{ fontWeight:700, color:'#012a01', fontSize:'0.9rem', margin:'0 0 16px', letterSpacing:'0.04em', textTransform:'uppercase' }}>
+              Marks Distribution
             </h3>
             <div className="ov-marks-bar-row">
               {marksData.map(({ range, count, color }) => {
@@ -308,7 +393,8 @@ export default function Overview() {
                   <div key={range} className="ov-marks-row">
                     <span className="ov-marks-label">{range}</span>
                     <div className="ov-marks-bar-wrap">
-                      <div className="ov-marks-bar-fill" style={{ width: `${pct}%`, background: color, minWidth: count > 0 ? 40 : 0 }}>
+                      <div className="ov-marks-bar-fill"
+                        style={{ width:`${pct}%`, background:color, minWidth: count > 0 ? 40 : 0 }}>
                         {count > 0 && count}
                       </div>
                     </div>

--- a/my-app/src/app/(pages)/dashboard/admin/_components/slotControl/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/slotControl/page.js
@@ -27,34 +27,56 @@ const S = {
   badge:   { display: 'inline-block', padding: '3px 12px', borderRadius: 20, fontSize: '0.75rem', fontWeight: 700 },
   badgeOn: { background: '#e6f4ea', color: '#014a01' },
   badgeOff:{ background: '#f5f5f5', color: '#aaa' },
-
-  // Toggle switch
-  switchWrap: { position: 'relative', width: 52, height: 28, cursor: 'pointer', flexShrink: 0 },
-  switchTrack: (on) => ({
-    width: '100%', height: '100%', borderRadius: 14,
-    background: on ? '#014a01' : '#d0d0d0',
-    transition: 'background 0.25s',
-    border: 'none', outline: 'none', cursor: 'pointer',
-    position: 'relative', display: 'block',
-  }),
-  switchThumb: (on) => ({
-    position: 'absolute', top: 3, left: on ? 26 : 3,
-    width: 22, height: 22, borderRadius: '50%',
-    background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,0.2)',
-    transition: 'left 0.25s',
-    pointerEvents: 'none',
-  }),
-
-  info: { fontSize: '0.8rem', color: '#666', lineHeight: 1.5 },
-  infoOn: { color: '#2e7d32' },
-
+  info:    { fontSize: '0.8rem', color: '#666', lineHeight: 1.5 },
+  infoOn:  { color: '#2e7d32' },
   loading: { textAlign: 'center', padding: 40, color: '#888' },
 };
+
+/* ── Slim 44×24 toggle switch ── */
+function Toggle({ on, busy, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={busy}
+      title={on ? 'Click to disable' : 'Click to enable'}
+      style={{
+        position: 'relative',
+        display: 'inline-block',
+        width: 44,
+        height: 24,
+        borderRadius: 12,
+        border: 'none',
+        outline: 'none',
+        cursor: busy ? 'not-allowed' : 'pointer',
+        background: on ? '#014a01' : '#d0d0d0',
+        transition: 'background 0.25s',
+        flexShrink: 0,
+        padding: 0,
+        opacity: busy ? 0.6 : 1,
+        verticalAlign: 'middle',
+      }}
+    >
+      <span style={{
+        position: 'absolute',
+        top: 3,
+        left: on ? 23 : 3,
+        width: 18,
+        height: 18,
+        borderRadius: '50%',
+        background: '#fff',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
+        transition: 'left 0.22s cubic-bezier(.4,0,.2,1)',
+        pointerEvents: 'none',
+        display: 'block',
+      }} />
+    </button>
+  );
+}
 
 export default function SlotControl() {
   const [slots, setSlots]       = useState([]);
   const [loading, setLoading]   = useState(true);
-  const [toggling, setToggling] = useState({}); // { slotNum: true/false }
+  const [toggling, setToggling] = useState({});
 
   useEffect(() => {
     (async () => {
@@ -102,7 +124,6 @@ export default function SlotControl() {
         </p>
       </div>
 
-      {/* Summary pill row */}
       <div style={{ display:'flex', gap:8, flexWrap:'wrap', marginBottom:24 }}>
         {slots.map(s => (
           <span key={s.slot} style={{
@@ -125,22 +146,14 @@ export default function SlotControl() {
                   <div style={S.slotNum}>Slot {slot}</div>
                   <div style={S.date}>📅 {SLOT_DATES[slot]}</div>
                 </div>
-                {/* Toggle */}
-                <button
-                  style={S.switchTrack(on)}
-                  onClick={() => !busy && toggle(slot, on)}
-                  disabled={busy}
-                  title={on ? 'Click to disable' : 'Click to enable'}
-                >
-                  <span style={S.switchThumb(on)} />
-                </button>
+                <Toggle on={on} busy={busy} onClick={() => !busy && toggle(slot, on)} />
               </div>
 
               <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center' }}>
                 <span style={{ ...S.badge, ...(on ? S.badgeOn : S.badgeOff) }}>
                   {on ? '✅ Active' : '🔒 Locked'}
                 </span>
-                {busy && <span style={{ fontSize:'0.75rem', color:'#888' }}>Updating…</span>}
+                {busy && <span style={{ fontSize:'0.72rem', color:'#888' }}>Updating…</span>}
               </div>
 
               <div style={{ ...S.info, ...(on ? S.infoOn : {}) }}>

--- a/my-app/src/app/(pages)/dashboard/admin/_components/stats/page.js
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/stats/page.js
@@ -115,29 +115,30 @@ export default function AdminDashboard() {
             <section className="stats-section">
                 <h2>Slot Statistics</h2>
                 <div className="stats-grid">
-                    {(stats?.availableSlots || Object.keys(stats?.slots || {}).map(k => parseInt(k.replace('slot','')))).map(slotNum => (
-                        <div key={slotNum} className="stat-card slot-card">
-                            <h3>Slot {slotNum}</h3>
-                            <div className="slot-stats">
-                                <div className="slot-stat">
-                                    <span>Total:</span>
-                                    <span>{stats?.slots[`slot${slotNum}`]?.total || 0}</span>
-                                </div>
-                                <div className="slot-stat">
-                                    <span>Remote:</span>
-                                    <span>{stats?.slots[`slot${slotNum}`]?.remote || 0}</span>
-                                </div>
-                                <div className="slot-stat">
-                                    <span>In Campus:</span>
-                                    <span>{stats?.slots[`slot${slotNum}`]?.incampus || 0}</span>
-                                </div>
-                                <div className="slot-stat">
-                                    <span>In Village:</span>
-                                    <span>{stats?.slots[`slot${slotNum}`]?.invillage || 0}</span>
+                    {(stats?.availableSlots || Object.keys(stats?.slots || {}).map(k => parseInt(k.replace('slot','')))).map(slotNum => {
+                        const s = stats?.slots?.[`slot${slotNum}`] || {};
+                        const total     = Math.max(0, Number(s.total)     || 0);
+                        const remote    = Math.max(0, Number(s.remote)    || 0);
+                        const incampus  = Math.max(0, Number(s.incampus)  || 0);
+                        const invillage = Math.max(0, Number(s.invillage) || 0);
+                        const unknown   = Math.max(0, Number(s.unknown)   || 0);
+                        return (
+                            <div key={slotNum} className="stat-card slot-card">
+                                <h3>Slot {slotNum}</h3>
+                                <div className="slot-stats">
+                                    <div className="slot-stat"><span>Total:</span><span>{total}</span></div>
+                                    <div className="slot-stat"><span>Remote:</span><span>{remote}</span></div>
+                                    <div className="slot-stat"><span>In Campus:</span><span>{incampus}</span></div>
+                                    <div className="slot-stat"><span>In Village:</span><span>{invillage}</span></div>
+                                    {unknown > 0 && (
+                                        <div className="slot-stat" style={{ color:'#e65100' }}>
+                                            <span>Other:</span><span>{unknown}</span>
+                                        </div>
+                                    )}
                                 </div>
                             </div>
-                        </div>
-                    ))}
+                        );
+                    })}
                 </div>
             </section>
 

--- a/my-app/src/app/(pages)/dashboard/admin/_components/students/page.css
+++ b/my-app/src/app/(pages)/dashboard/admin/_components/students/page.css
@@ -507,22 +507,28 @@
 
 .search-group .search-icon {
   position: absolute;
-  left: 15px;
-  color: #888;
-  font-size: 16px;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #aaa;
+  font-size: 15px;
+  width: 15px;
+  height: 15px;
   pointer-events: none;
   z-index: 1;
+  flex-shrink: 0;
 }
 
 .search-group input {
   width: 100%;
-  padding: 12px 16px 12px 45px; /* Increased left padding to avoid overlap */
+  padding: 11px 16px 11px 38px; /* 38px left = 12px offset + 15px icon + 11px gap */
   border: 1px solid #dee2e6;
   border-radius: 8px;
-  font-size: 15px;
+  font-size: 14px;
   transition: all 0.2s ease;
   background-color: #fff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.02);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  box-sizing: border-box;
 }
 
 .search-group input:focus {

--- a/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/page.js
+++ b/my-app/src/app/(pages)/dashboard/student/_components/dailyTasks/page.js
@@ -38,10 +38,16 @@ function dayLabel(slot, dayNum) {
   return dl.toLocaleDateString('en-IN', { month: 'short', day: 'numeric' });
 }
 
+const DEMO_ID = '2500099999';
+
 /**
  * Status: 'upcoming' | 'open' | 'submitted' | 'missed' | 'locked'
  */
-function getDayStatus(dayNum, slot, saved) {
+function getDayStatus(dayNum, slot, saved, username) {
+  // ── Demo bypass: all days open regardless of date ──
+  if (username === DEMO_ID) {
+    return saved[dayNum] ? 'submitted' : 'open';
+  }
   if (!slot || !SLOT_START[slot]) return 'upcoming';
   const dl = dayDeadline(slot, dayNum);
   const now = serverNow();   // ← server-authoritative IST time
@@ -51,7 +57,7 @@ function getDayStatus(dayNum, slot, saved) {
   if (dayNum === 1) {
     return now >= SLOT_START[slot].getTime() ? 'open' : 'upcoming';
   }
-  const prevStatus = getDayStatus(dayNum - 1, slot, saved);
+  const prevStatus = getDayStatus(dayNum - 1, slot, saved, username);
   if (prevStatus === 'missed' || prevStatus === 'locked') return 'locked';
   if (prevStatus !== 'submitted') return 'upcoming';
   return 'open';
@@ -148,9 +154,10 @@ export default function DailyTasks({ studentData }) {
   const [msg, setMsg]         = useState('');
   const [msgType, setMsgType] = useState('ok');
 
-  const ps     = studentData?.problemStatementData?.problem_statement || null;
-  const slot   = studentData?.slot || null;
-  const survey = ps ? (SURVEY[ps] || null) : null;
+  const ps       = studentData?.problemStatementData?.problem_statement || null;
+  const slot     = studentData?.slot || null;
+  const username = studentData?.username || null;
+  const survey   = ps ? (SURVEY[ps] || null) : null;
 
   useEffect(() => {
     (async () => {
@@ -166,7 +173,7 @@ export default function DailyTasks({ studentData }) {
         const tasks = (json.success && json.tasks) ? json.tasks : {};
         setSaved(tasks);
         const firstOpen = [1,2,3,4,5,6,7].find(d => {
-          const st = getDayStatus(d, slot, tasks);
+          const st = getDayStatus(d, slot, tasks, username);
           return st === 'open' || st === 'submitted';
         });
         setActiveDay(firstOpen || 1);
@@ -218,7 +225,7 @@ export default function DailyTasks({ studentData }) {
 
   if (activeDay === null) return <div className="dt-wrap"><p style={{color:'#888'}}>Loading…</p></div>;
 
-  const statuses    = Object.fromEntries([1,2,3,4,5,6,7].map(d => [d, getDayStatus(d, slot, saved)]));
+  const statuses    = Object.fromEntries([1,2,3,4,5,6,7].map(d => [d, getDayStatus(d, slot, saved, username)]));
   const meta        = DAY_META[activeDay - 1];
   const activeStatus = statuses[activeDay];
   const isSaved     = activeStatus === 'submitted' && !draft[activeDay];

--- a/my-app/src/app/api/dashboard/admin/stats/route.js
+++ b/my-app/src/app/api/dashboard/admin/stats/route.js
@@ -19,14 +19,14 @@ export async function GET() {
     const [slotRows] = await pool.query(`
       SELECT
         slot,
-        COUNT(*) AS total,
-        SUM(CASE WHEN LOWER(TRIM(mode)) = 'remote'   THEN 1 ELSE 0 END) AS remote,
-        SUM(CASE WHEN LOWER(TRIM(mode)) = 'incampus'  THEN 1 ELSE 0 END) AS incampus,
-        SUM(CASE WHEN LOWER(TRIM(mode)) = 'invillage' THEN 1 ELSE 0 END) AS invillage
+        COUNT(*)                                                                 AS total,
+        SUM(CASE WHEN LOWER(TRIM(COALESCE(mode,''))) IN ('remote','hometown') THEN 1 ELSE 0 END) AS remote,
+        SUM(CASE WHEN LOWER(TRIM(COALESCE(mode,''))) IN ('incampus','in campus','in-campus') THEN 1 ELSE 0 END) AS incampus,
+        SUM(CASE WHEN LOWER(TRIM(COALESCE(mode,''))) IN ('invillage','in village','in-village') THEN 1 ELSE 0 END) AS invillage
       FROM registrations
       WHERE slot IS NOT NULL
       GROUP BY slot
-      ORDER BY slot
+      ORDER BY CAST(slot AS UNSIGNED)
     `);
 
     // ── Overview totals ───────────────────────────────────────────────────────
@@ -49,12 +49,13 @@ export async function GET() {
     slotRows.forEach(row => {
       const n = row.slot;
       availableSlots.push(n);
-      slotsObj[`slot${n}`] = {
-        total:     Number(row.total)     || 0,
-        remote:    Number(row.remote)    || 0,
-        incampus:  Number(row.incampus)  || 0,
-        invillage: Number(row.invillage) || 0,
-      };
+      const remote    = Math.max(0, Number(row.remote)    || 0);
+      const incampus  = Math.max(0, Number(row.incampus)  || 0);
+      const invillage = Math.max(0, Number(row.invillage) || 0);
+      const total     = Math.max(0, Number(row.total)     || 0);
+      // unknown = rows whose mode didn't match any known value
+      const unknown   = Math.max(0, total - remote - incampus - invillage);
+      slotsObj[`slot${n}`] = { total, remote, incampus, invillage, unknown };
     });
 
     // ── Domain stats: include ALL 20 domains, even those with 0 students ──────

--- a/my-app/src/app/api/seed-demo/route.js
+++ b/my-app/src/app/api/seed-demo/route.js
@@ -1,0 +1,202 @@
+/**
+ * POST /api/seed-demo
+ * One-shot admin-only endpoint to seed the demo student (2500099999).
+ * Idempotent — safe to call multiple times.
+ */
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import bcrypt from 'bcryptjs';
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/lib/jwt';
+
+const DEMO_ID = '2500099999';
+const DEMO_PHONE = '9999000001';
+
+const DAILY_TASKS = {
+  1: {
+    location: 'KL University Campus, Guntur',
+    problemUnderstanding: 'Smallholder farmers in Andhra Pradesh lack access to timely, accurate crop disease diagnosis. Current methods rely on manual inspection which is slow and error-prone, leading to significant crop loss annually.',
+    rootCause: 'Limited agricultural extension services, poor internet penetration in rural areas, and absence of affordable AI tools tailored for local crop varieties.',
+    inference: 'An AI-based mobile application trained on local field imagery could reduce crop loss by up to 40% if adopted at scale.',
+  },
+  2: {
+    surveyTarget: 'Farmers, Agricultural Officers',
+    totalSurveyed: 30,
+    responses: [
+      { question: 'Do you use any digital tool for crop disease detection?', yes: 3, no: 27 },
+      { question: 'Are you willing to learn a smartphone app if it helps?', yes: 22, no: 8 },
+      { question: 'Have you experienced major crop loss due to disease?', yes: 26, no: 4 },
+    ],
+  },
+  3: {
+    surveyTarget: 'Students, Agri-Tech Professionals',
+    totalSurveyed: 25,
+    responses: [
+      { question: 'Are you aware of ML-based crop disease detection tools?', yes: 18, no: 7 },
+      { question: 'Would you recommend such tools to rural farmers?', yes: 23, no: 2 },
+    ],
+  },
+  4: {
+    surveyTarget: 'Village Panchayat Members, Self-Help Groups',
+    totalSurveyed: 20,
+    responses: [
+      { question: 'Is internet connectivity adequate in your village?', yes: 6, no: 14 },
+      { question: 'Would offline AI tools be useful?', yes: 19, no: 1 },
+    ],
+  },
+  5: {
+    yesPercentages: { Q1: 10, Q2: 73, Q3: 87, Q4: 24, Q5: 95 },
+    noPercentages:  { Q1: 90, Q2: 27, Q3: 13, Q4: 76, Q5: 5  },
+    rootCauses: [
+      'Poor digital literacy among older farmers',
+      'Lack of local-language AI tools',
+      'No consistent internet in rural zones',
+      'High cost of smart devices',
+    ],
+    analysis: 'Over 87% of farmers have experienced crop loss yet only 10% use any digital solution, indicating a massive unmet need. Offline-capable AI tools in Telugu would have the highest adoption probability.',
+  },
+  6: {
+    activityTitle: 'AI Crop Disease Awareness Camp',
+    activityDate: '2026-05-16',
+    location: 'Nadendla Village, Guntur District',
+    participants: 45,
+    description: 'Conducted a hands-on demonstration of the prototype ML app trained on 5000+ local crop images. Farmers photographed diseased leaves and received instant diagnosis. Distributed printed guides in Telugu.',
+    driveLink: 'https://drive.google.com/drive/folders/demo_intervention_folder',
+    photos: ['photo1.jpg', 'photo2.jpg'],
+  },
+  7: {
+    reportTitle: 'AI-Powered Crop Disease Detection for Rural Andhra Pradesh',
+    abstract: 'This case study documents a 7-day field internship investigating the feasibility of deploying ML-based crop disease detection in rural Guntur district. Survey data from 75 respondents and a live intervention camp reveal strong unmet demand and a viable technology pathway.',
+    methodology: 'Mixed-methods: structured surveys, stakeholder interviews, and prototype demonstration.',
+    findings: 'Local farmers overwhelmingly prefer offline, Telugu-language tools; 95% expressed willingness to adopt given free or subsidised access.',
+    recommendations: 'Partner with KVKs to deploy offline-first Android app; integrate with PM-Kisan database for farmer targeting.',
+    youtubeLink: 'https://youtube.com/watch?v=demo_presentation',
+    driveLink: 'https://drive.google.com/drive/folders/demo_final_report',
+  },
+};
+
+export async function POST() {
+  try {
+    // Auth guard — admin only
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const decoded = await verifyAccessToken(token);
+    if (decoded.role !== 'admin') return NextResponse.json({ error: 'Admin only' }, { status: 403 });
+
+    const db = await pool.getConnection();
+    try {
+      const passwordHash = await bcrypt.hash(`${DEMO_ID}${DEMO_PHONE.slice(-4)}`, 10);
+
+      // ── 1. users ──────────────────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO users (name, username, password, role)
+         VALUES (?, ?, ?, 'student')
+         ON DUPLICATE KEY UPDATE name=VALUES(name), password=VALUES(password)`,
+        ['Demo Student', DEMO_ID, passwordHash]
+      );
+
+      // ── 2. registrations ─────────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO registrations
+           (selectedDomain, fieldOfInterest, careerChoice, batch, mode, slot, username, name, email,
+            branch, gender, year, phoneNumber, residenceType, hostelName, busRoute,
+            country, state, district, pincode, season)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON DUPLICATE KEY UPDATE
+           selectedDomain=VALUES(selectedDomain), mode=VALUES(mode), slot=VALUES(slot),
+           name=VALUES(name), email=VALUES(email)`,
+        [
+          'Machine Learning & AI', 'Data Science', 'Software Engineer', '2022-2026',
+          'Incampus', 1, DEMO_ID, 'Demo Student', 'demo@kluniversity.in',
+          'Computer Science & Engineering', 'Male', '3rd Year', DEMO_PHONE,
+          'Hostel', 'KL Boys Hostel A', null,
+          'India', 'Andhra Pradesh', 'Guntur', '522502', '2026'
+        ]
+      );
+
+      // ── 3. problemStatements ─────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO problemStatements (username, domain, problem_statement, location, district, state)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE problem_statement=VALUES(problem_statement)`,
+        [
+          DEMO_ID, 'Machine Learning & AI',
+          'Analysing the impact of AI-driven crop disease detection tools on smallholder farmers in rural Andhra Pradesh using ML models trained on local field imagery.',
+          'KL University Campus', 'Guntur', 'Andhra Pradesh'
+        ]
+      );
+
+      // ── 4. marks ─────────────────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO marks (username, internalMarks, finalReport, finalPresentation, grade, completed)
+         VALUES (?, 92, 19, 18, 'A', 'P')
+         ON DUPLICATE KEY UPDATE internalMarks=92, finalReport=19, finalPresentation=18, grade='A', completed='P'`
+        , [DEMO_ID]
+      );
+
+      // ── 5. final ─────────────────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO final (username, completed) VALUES (?, 1)
+         ON DUPLICATE KEY UPDATE completed=1`,
+        [DEMO_ID]
+      );
+
+      // ── 6. verify ────────────────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO verify (username, day1, day2, day3, day4, day5, day6, day7)
+         VALUES (?, true, true, true, true, true, true, true)
+         ON DUPLICATE KEY UPDATE
+           day1=true, day2=true, day3=true, day4=true, day5=true, day6=true, day7=true`,
+        [DEMO_ID]
+      );
+
+      // ── 7. attendance ────────────────────────────────────────────────────────
+      await db.query(
+        `INSERT INTO attendance (username, day1, day2, day3, day4, day5, day6, day7)
+         VALUES (?, 'Present','Present','Present','Present','Present','Present','Present')
+         ON DUPLICATE KEY UPDATE
+           day1='Present', day2='Present', day3='Present', day4='Present',
+           day5='Present', day6='Present', day7='Present'`,
+        [DEMO_ID]
+      );
+
+      // ── 8. dailyTasks — all 7 days ───────────────────────────────────────────
+      await db.query(`
+        CREATE TABLE IF NOT EXISTS dailyTasks (
+          id          INT          AUTO_INCREMENT PRIMARY KEY,
+          username    VARCHAR(255) NOT NULL,
+          day         TINYINT      NOT NULL,
+          data        JSON         NOT NULL,
+          submittedAt TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+          updatedAt   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uq_user_day (username, day)
+        )
+      `);
+
+      for (const [day, taskData] of Object.entries(DAILY_TASKS)) {
+        await db.query(
+          `INSERT INTO dailyTasks (username, day, data)
+           VALUES (?, ?, ?)
+           ON DUPLICATE KEY UPDATE data=VALUES(data), updatedAt=CURRENT_TIMESTAMP`,
+          [DEMO_ID, parseInt(day), JSON.stringify(taskData)]
+        );
+      }
+
+      // ── 9. slotControl — enable Slot 1 ──────────────────────────────────────
+      await db.query(
+        `INSERT INTO slotControl (slot, enabled) VALUES (1, 1)
+         ON DUPLICATE KEY UPDATE enabled=1`
+      );
+
+      return NextResponse.json({
+        success: true,
+        message: 'Demo student 2500099999 seeded successfully.',
+        login: { username: DEMO_ID, password: `${DEMO_ID}${DEMO_PHONE.slice(-4)}` },
+      });
+    } finally { db.release(); }
+  } catch (e) {
+    console.error('Seed error:', e);
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/slot-status/route.js
+++ b/my-app/src/app/api/slot-status/route.js
@@ -13,6 +13,11 @@ export async function GET() {
     const decoded = await verifyAccessToken(token);
     const username = decoded.username;
 
+    // ── Demo student bypass — always fully unlocked ───────────────────────────
+    if (username === '2500099999') {
+      return NextResponse.json({ success: true, slot: 1, enabled: true });
+    }
+
     const db = await pool.getConnection();
     try {
       // Get the student's slot


### PR DESCRIPTION
- Replace emoji KPI icons with Ant Design SVG icons (TeamOutlined, CheckCircleOutlined, etc.)
- Replace geo bar chart with donut PieChart (custom tooltip, legend, hover dimming, centre total)
- Fix slot toggle switch: slim 44x24px fixed-size, no more full-width fat button
- Fix negative slot mode counts: expand LOWER(TRIM(mode)) IN() to handle all case variants
- Clamp all slot stats values to Math.max(0) in UI and API
- Fix search icon overlap in students page: icon vertically centred with transform translateY(-50%)
- Add Evaluation Plan page to student sidebar (always visible, no slot gate)
- Add Slot Control page to admin sidebar with slim toggle switches
- Add /api/seed-demo: one-shot admin endpoint to seed demo student 2500099999
- Demo student bypasses slot gate and daily task date/time locks entirely
- Daily tasks getDayStatus now accepts username param for demo bypass
- Remove dead seed-demo-student.sql reference file